### PR TITLE
:bookmark: release v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7
+
+- [FIX] disable `DecodeOptions.decodeDotInKeys` by default to restore previous behavior
+
 ## 1.0.6
 
 - [FEAT] add support for `Set`s

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: qs_dart
 description: A query string encoding and decoding library for Dart. Ported from qs for JavaScript.
-version: 1.0.6
+version: 1.0.7
 repository: https://github.com/techouse/qs
 
 environment:


### PR DESCRIPTION
## 1.0.7

- [FIX] disable `DecodeOptions.decodeDotInKeys` by default to restore previous behavior