### PR TITLE
:bookmark: release v1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.0.8
 
-- [FEAT] port JavaScript's `String.prototype.slice()` method to Dart and use that instead of `String.substring()`
+- [FEAT] port `String.prototype.slice()` from JavaScript and use that instead of Dart's `String.substring()`
+- [CHORE] add comparison test between output of qs_dart and [qs](https://www.npmjs.com/package/qs)
+- [CHORE] update test to 1.25.3 (was 1.25.2)
+- [CHORE] update path to 1.9.0 (was 1.8.0)
 
 ## 1.0.7+1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.8
+
+- [FEAT] port JavaScript's `String.prototype.slice()` method to Dart and use that instead of `String.substring()`
+
 ## 1.0.7+1
 
 - [FIX] fix optimization regressions introduced in v1.0.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: qs_dart
 description: A query string encoding and decoding library for Dart. Ported from qs for JavaScript.
-version: 1.0.7+1
+version: 1.0.8
 repository: https://github.com/techouse/qs
 
 environment:


### PR DESCRIPTION
## 1.0.8

- [FEAT] port `String.prototype.slice()` from JavaScript and use that instead of Dart's `String.substring()`
- [CHORE] add comparison test between output of qs_dart and [qs](https://www.npmjs.com/package/qs)
- [CHORE] update test to 1.25.3 (was 1.25.2)
- [CHORE] update path to 1.9.0 (was 1.8.0)