### PR TITLE
:bug: fix incorrect parsing of nested params with closing square bracket ] in the property name

### DIFF
--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -159,7 +159,10 @@ extension _$Decode on QS {
         : givenKey!;
 
     // The regex chunks
-    final RegExp brackets = RegExp(r'(\[[^[\]]*])');
+    final RegExp brackets = RecursiveRegex(
+      startDelimiter: '[',
+      endDelimiter: ']',
+    );
 
     // Get the parent
     Match? segment = options.depth > 0 ? brackets.firstMatch(key) : null;
@@ -178,7 +181,7 @@ extension _$Decode on QS {
         i < options.depth) {
       i += 1;
       if (segment != null) {
-        keys.add(segment.group(1)!);
+        keys.add(segment.group(0)!);
         // Update the key to start searching from the next position
         key = key.slice(segment.end);
       }

--- a/lib/src/qs.dart
+++ b/lib/src/qs.dart
@@ -10,6 +10,7 @@ import 'package:qs_dart/src/models/decode_options.dart';
 import 'package:qs_dart/src/models/encode_options.dart';
 import 'package:qs_dart/src/models/undefined.dart';
 import 'package:qs_dart/src/utils.dart';
+import 'package:recursive_regex/recursive_regex.dart';
 import 'package:weak_map/weak_map.dart';
 
 part 'extensions/decode.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   collection: ^1.18.0
   equatable: ^2.0.5
   meta: ^1.9.1
+  recursive_regex: ^1.0.0
   weak_map: ^3.0.1
 
 dev_dependencies:

--- a/test/unit/fixed_qs_issues_test.dart
+++ b/test/unit/fixed_qs_issues_test.dart
@@ -1,0 +1,19 @@
+import 'package:qs_dart/qs_dart.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('fixed ljharb/qs issues', () {
+    test('ljharb/qs#493', () {
+      final Map<String, dynamic> original = {
+        'search': {'withbracket[]': 'foobar'}
+      };
+      final String encoded = 'search[withbracket[]]=foobar';
+
+      expect(
+        QS.encode(original, EncodeOptions(encode: false)),
+        equals(encoded),
+      );
+      expect(QS.decode(encoded), equals(original));
+    });
+  });
+}


### PR DESCRIPTION
## Description

Fixes incorrect parsing of nested params with closing square bracket `]` in the property name.

The regular expression you're currently in use,

```dart
RegExp(r'(\[[^[\]]*])');
```

matches a left bracket `[`, followed by any number of characters that are not brackets, and then a right bracket `]`. This is why it matches the innermost brackets.

To match the outermost brackets, including nested brackets, we must use a recursive regular expression. However, Dart's built-in `RegExp` module doesn't support recursive regular expressions, so we must use the [recursive_regex ](https://pub.dev/packages/recursive_regex/install) module instead, which is a third-party module that provides more advanced regular expression features.

```dart
import 'package:recursive_regex/recursive_regex.dart';

String? matchOutermostBrackets(String s) {
  final RegExp pattern = RecursiveRegex(
    startDelimiter: '[',
    endDelimiter: ']',
  );
  final Match? match = pattern.firstMatch(s);
  return match?.group(0);
}

void main() {
  print(matchOutermostBrackets('foo[bar[]]'));  // Outputs: [bar[]]
}
```

Fixes https://github.com/ljharb/qs/issues/493

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] tested encoding and decoding an offending `String`
```dart
import 'package:qs_dart/qs_dart.dart';
import 'package:test/test.dart';

test('ljharb/qs#493', () {
  final Map<String, dynamic> original = {
    'search': {'withbracket[]': 'foobar'}
  };
  final String encoded = 'search[withbracket[]]=foobar';

  expect(
    QS.encode(original, EncodeOptions(encode: false)),
    equals(encoded),
  );
  expect(QS.decode(encoded), equals(original));
});
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
