### PR TITLE
:bookmark: release v1.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.9
+
+- [FIX] incorrect parsing of nested params with closing square bracket `]` in the property name ([#12](https://github.com/techouse/qs/pull/12))
+
 ## 1.0.8+1
 
 - [CHORE] update readme / documentation

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: qs_dart
 description: A query string encoding and decoding library for Dart. Ported from qs for JavaScript.
-version: 1.0.8+1
+version: 1.0.9
 repository: https://github.com/techouse/qs
 
 environment:
@@ -18,7 +18,7 @@ dev_dependencies:
   euc: ^1.0.6+8
   lints: ^3.0.0
   path: ^1.9.0
-  test: ^1.25.3
+  test: ^1.25.4
 
 topics:
   - url


### PR DESCRIPTION
## 1.0.9

- [FIX] incorrect parsing of nested params with closing square bracket `]` in the property name (#12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue with incorrect parsing of nested parameters in property names.

- **Chores**
  - Updated the library version and test dependency to enhance performance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->