### PR TITLE
:zap: decode returns `Map<String, dynamic>` instead of `Map`

### DIFF
--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -13,11 +13,11 @@ extension _$Decode on QS {
           ? val.split(',')
           : val;
 
-  static Map _parseQueryStringValues(
+  static Map<String, dynamic> _parseQueryStringValues(
     String str, [
     DecodeOptions options = const DecodeOptions(),
   ]) {
-    final Map obj = {};
+    final Map<String, dynamic> obj = {};
 
     final String cleanStr =
         options.ignoreQueryPrefix ? str.replaceFirst('?', '') : str;
@@ -107,7 +107,7 @@ extension _$Decode on QS {
             ? List<dynamic>.empty(growable: true)
             : [if (leaf is Iterable) ...leaf else leaf];
       } else {
-        obj = Map.of({});
+        obj = <String, dynamic>{};
         final String cleanRoot = root.startsWith('[') && root.endsWith(']')
             ? root.slice(1, root.length - 1)
             : root;
@@ -116,7 +116,7 @@ extension _$Decode on QS {
             : cleanRoot;
         final int? index = int.tryParse(decodedRoot);
         if (!options.parseLists && decodedRoot == '') {
-          obj = Map.of({0: leaf});
+          obj = <String, dynamic>{'0': leaf};
         } else if (index != null &&
             index >= 0 &&
             root != decodedRoot &&
@@ -130,7 +130,7 @@ extension _$Decode on QS {
           );
           obj[index] = leaf;
         } else {
-          obj[index ?? decodedRoot] = leaf;
+          obj[index?.toString() ?? decodedRoot] = leaf;
         }
       }
 

--- a/lib/src/extensions/extensions.dart
+++ b/lib/src/extensions/extensions.dart
@@ -26,6 +26,4 @@ extension StringExtension on String {
     }
     return substring(start, min(end, length));
   }
-
-  bool get isNumeric => double.tryParse(this) != null;
 }

--- a/lib/src/extensions/extensions.dart
+++ b/lib/src/extensions/extensions.dart
@@ -26,4 +26,6 @@ extension StringExtension on String {
     }
     return substring(start, min(end, length));
   }
+
+  bool get isNumeric => double.tryParse(this) != null;
 }

--- a/lib/src/methods.dart
+++ b/lib/src/methods.dart
@@ -3,7 +3,7 @@ import 'package:qs_dart/src/models/encode_options.dart';
 import 'package:qs_dart/src/qs.dart';
 
 /// Convenience method for [QS.decode]
-Map decode(
+Map<String, dynamic> decode(
   dynamic input, [
   DecodeOptions options = const DecodeOptions(),
 ]) =>

--- a/lib/src/qs.dart
+++ b/lib/src/qs.dart
@@ -19,43 +19,45 @@ part 'extensions/encode.dart';
 
 /// A query string decoder (parser) and encoder (stringifier) class.
 final class QS {
-  /// Decodes a [String] or [Map] into a [Map].
+  /// Decodes a [String] or [Map<String, dynamic>] into a [Map<String, dynamic>].
   /// Providing custom [options] will override the default behavior.
-  static Map decode(
+  static Map<String, dynamic> decode(
     dynamic input, [
     DecodeOptions options = const DecodeOptions(),
   ]) {
-    if (!(input is String? || input is Map?)) {
+    if (!(input is String? || input is Map<String, dynamic>?)) {
       throw ArgumentError.value(
         input,
         'input',
-        'The input must be a String or a Map',
+        'The input must be a String or a Map<String, dynamic>',
       );
     }
 
     if (input?.isEmpty ?? true) {
-      return Map.of({});
+      return <String, dynamic>{};
     }
 
-    Map? tempObj = input is String
+    Map<String, dynamic>? tempObj = input is String
         ? _$Decode._parseQueryStringValues(input, options)
         : input;
-    Map obj = {};
+    Map<String, dynamic> obj = {};
 
     // Iterate over the keys and setup the new object
-    for (final MapEntry entry in tempObj?.entries ?? List.empty()) {
-      final newObj = _$Decode._parseKeys(
-        entry.key,
-        entry.value,
-        options,
-        input is String,
-      );
+    if (tempObj?.isNotEmpty ?? false) {
+      for (final MapEntry<String, dynamic> entry in tempObj!.entries) {
+        final newObj = _$Decode._parseKeys(
+          entry.key,
+          entry.value,
+          options,
+          input is String,
+        );
 
-      obj = Utils.merge(
-        obj,
-        newObj,
-        options,
-      );
+        obj = Utils.merge(
+          obj,
+          newObj,
+          options,
+        );
+      }
     }
 
     return Utils.compact(obj);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -87,11 +87,12 @@ final class Utils {
         }
       } else if (target is Map) {
         if (source is Iterable) {
-          target = Map.of(target)
-            ..addAll({
-              for (final (int i, dynamic item) in source.indexed)
-                if (item is! Undefined) i: item
-            });
+          target = <String, dynamic>{
+            for (final MapEntry entry in target.entries)
+              entry.key.toString(): entry.value,
+            for (final (int i, dynamic item) in source.indexed)
+              if (item is! Undefined) i.toString(): item
+          };
         }
       } else if (source != null) {
         if (target is! Iterable && source is Iterable) {
@@ -105,9 +106,9 @@ final class Utils {
 
     if (target == null || target is! Map) {
       if (target is Iterable) {
-        return Map.of({
+        return Map<String, dynamic>.of({
           for (final (int i, dynamic item) in target.indexed)
-            if (item is! Undefined) i: item,
+            if (item is! Undefined) i.toString(): item,
           ...source,
         });
       }
@@ -124,13 +125,16 @@ final class Utils {
       ];
     }
 
-    Map mergeTarget = target is Iterable && source is! Iterable
-        ? (target as Iterable).toList().whereNotUndefined().asMap()
-        : Map.of(target);
+    Map<String, dynamic> mergeTarget = target is Iterable && source is! Iterable
+        ? {
+            for (final (int i, dynamic item) in (target as Iterable).indexed)
+              if (item is! Undefined) i.toString(): item
+          }
+        : Map<String, dynamic>.of(target as Map<String, dynamic>);
 
     return source.entries.fold(mergeTarget, (Map acc, MapEntry entry) {
       acc.update(
-        entry.key,
+        entry.key.toString(),
         (value) => merge(
           value,
           entry.value,
@@ -332,8 +336,8 @@ final class Utils {
     }
   }
 
-  static Map compact(Map value) {
-    final List<Map> queue = [
+  static Map<String, dynamic> compact(Map<String, dynamic> value) {
+    final List<Map<String, dynamic>> queue = [
       {
         'obj': {'o': value},
         'prop': 'o',

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -130,7 +130,10 @@ final class Utils {
             for (final (int i, dynamic item) in (target as Iterable).indexed)
               if (item is! Undefined) i.toString(): item
           }
-        : Map<String, dynamic>.of(target as Map<String, dynamic>);
+        : {
+            for (final MapEntry entry in target.entries)
+              entry.key.toString(): entry.value
+          };
 
     return source.entries.fold(mergeTarget, (Map acc, MapEntry entry) {
       acc.update(

--- a/test/fixtures/data/empty_test_cases.dart
+++ b/test/fixtures/data/empty_test_cases.dart
@@ -244,8 +244,8 @@ const List<Map<String, dynamic>> emptyTestCases = [
       'repeat': '=a&=b& =1'
     },
     'noEmptyKeys': {
-      0: 'a',
-      1: 'b',
+      '0': 'a',
+      '1': 'b',
       ' ': ['1']
     }
   },
@@ -256,8 +256,8 @@ const List<Map<String, dynamic>> emptyTestCases = [
       'a': ['1', '2']
     },
     'noEmptyKeys': {
-      0: 'a',
-      1: 'b',
+      '0': 'a',
+      '1': 'b',
       'a': ['1', '2']
     },
     'stringifyOutput': {
@@ -292,6 +292,6 @@ const List<Map<String, dynamic>> emptyTestCases = [
       'indices': '[0]=a&[1]=b',
       'repeat': '=a&=b'
     },
-    'noEmptyKeys': {0: 'a', 1: 'b'}
+    'noEmptyKeys': {'0': 'a', '1': 'b'}
   }
 ];

--- a/test/unit/array_test.dart
+++ b/test/unit/array_test.dart
@@ -7,17 +7,21 @@ import 'package:test/test.dart';
 void main() {
   group('SplayTreeMap', () {
     test('indices are ordered in value', () {
-      final SplayTreeMap<int, String> array =
-          SplayTreeMap<int, String>.from({1: 'a', 0: 'b', 2: 'c'});
+      final SplayTreeMap<String, String> array =
+          SplayTreeMap<String, String>.from({
+        '1': 'a',
+        '0': 'b',
+        '2': 'c',
+      });
 
       expect(array.values, ['b', 'a', 'c']);
     });
 
     test('indices are ordered in value 2', () {
-      final SplayTreeMap<int, String> array = SplayTreeMap<int, String>();
-      array[1] = 'c';
-      array[0] = 'b';
-      array[2] = 'd';
+      final SplayTreeMap<String, String> array = SplayTreeMap<String, String>();
+      array['1'] = 'c';
+      array['0'] = 'b';
+      array['2'] = 'd';
 
       expect(array.values, ['b', 'c', 'd']);
     });

--- a/test/unit/decode_test.dart
+++ b/test/unit/decode_test.dart
@@ -17,7 +17,7 @@ void main() {
     });
 
     test('parses a simple string', () {
-      expect(QS.decode('0=foo'), equals({0: 'foo'}));
+      expect(QS.decode('0=foo'), equals({'0': 'foo'}));
       expect(QS.decode('foo=c++'), equals({'foo': 'c  '}));
       expect(
         QS.decode('a[>=]=23'),
@@ -471,7 +471,7 @@ void main() {
       expect(
         QS.decode('a[1]=c', const DecodeOptions(listLimit: 0)),
         equals({
-          'a': {1: 'c'}
+          'a': {'1': 'c'}
         }),
       );
       expect(
@@ -492,7 +492,7 @@ void main() {
       expect(
         QS.decode('a[21]=a', const DecodeOptions(listLimit: 20)),
         equals({
-          'a': {21: 'a'}
+          'a': {'21': 'a'}
         }),
       );
 
@@ -505,7 +505,7 @@ void main() {
       expect(
         QS.decode('a[21]=a'),
         equals({
-          'a': {21: 'a'}
+          'a': {'21': 'a'}
         }),
       );
     });
@@ -561,31 +561,31 @@ void main() {
       expect(
         QS.decode('foo[0]=bar&foo[bad]=baz'),
         equals({
-          'foo': {0: 'bar', 'bad': 'baz'}
+          'foo': {'0': 'bar', 'bad': 'baz'}
         }),
       );
       expect(
         QS.decode('foo[bad]=baz&foo[0]=bar'),
         equals({
-          'foo': {'bad': 'baz', 0: 'bar'}
+          'foo': {'bad': 'baz', '0': 'bar'}
         }),
       );
       expect(
         QS.decode('foo[bad]=baz&foo[]=bar'),
         equals({
-          'foo': {'bad': 'baz', 0: 'bar'}
+          'foo': {'bad': 'baz', '0': 'bar'}
         }),
       );
       expect(
         QS.decode('foo[]=bar&foo[bad]=baz'),
         equals({
-          'foo': {0: 'bar', 'bad': 'baz'}
+          'foo': {'0': 'bar', 'bad': 'baz'}
         }),
       );
       expect(
         QS.decode('foo[bad]=baz&foo[]=bar&foo[]=foo'),
         equals({
-          'foo': {'bad': 'baz', 0: 'bar', 1: 'foo'}
+          'foo': {'bad': 'baz', '0': 'bar', '1': 'foo'}
         }),
       );
       expect(
@@ -664,28 +664,28 @@ void main() {
         QS.decode(
             'foo.bad=baz&foo[0]=bar', const DecodeOptions(allowDots: true)),
         equals({
-          'foo': {'bad': 'baz', 0: 'bar'}
+          'foo': {'bad': 'baz', '0': 'bar'}
         }),
       );
       expect(
         QS.decode(
             'foo.bad=baz&foo[]=bar', const DecodeOptions(allowDots: true)),
         equals({
-          'foo': {'bad': 'baz', 0: 'bar'}
+          'foo': {'bad': 'baz', '0': 'bar'}
         }),
       );
       expect(
         QS.decode(
             'foo[]=bar&foo.bad=baz', const DecodeOptions(allowDots: true)),
         equals({
-          'foo': {0: 'bar', 'bad': 'baz'}
+          'foo': {'0': 'bar', 'bad': 'baz'}
         }),
       );
       expect(
         QS.decode('foo.bad=baz&foo[]=bar&foo[]=foo',
             const DecodeOptions(allowDots: true)),
         equals({
-          'foo': {'bad': 'baz', 0: 'bar', 1: 'foo'}
+          'foo': {'bad': 'baz', '0': 'bar', '1': 'foo'}
         }),
       );
       expect(
@@ -705,7 +705,7 @@ void main() {
       expect(
         QS.decode('a[2]=b&a[99999999]=c'),
         equals({
-          'a': {2: 'b', 99999999: 'c'}
+          'a': {'2': 'b', '99999999': 'c'}
         }),
       );
     });
@@ -889,13 +889,13 @@ void main() {
     });
 
     test('continues parsing when no parent is found', () {
-      expect(QS.decode('[]=&a=b'), equals({0: '', 'a': 'b'}));
+      expect(QS.decode('[]=&a=b'), equals({'0': '', 'a': 'b'}));
       expect(
         QS.decode(
           '[]&a=b',
           const DecodeOptions(strictNullHandling: true),
         ),
-        equals({0: null, 'a': 'b'}),
+        equals({'0': null, 'a': 'b'}),
       );
       expect(QS.decode('[foo]=bar'), equals({'foo': 'bar'}));
     });
@@ -945,7 +945,7 @@ void main() {
       expect(
         QS.decode('a[0]=b', const DecodeOptions(listLimit: -1)),
         equals({
-          'a': {0: 'b'}
+          'a': {'0': 'b'}
         }),
       );
       expect(
@@ -958,26 +958,26 @@ void main() {
       expect(
         QS.decode('a[-1]=b', const DecodeOptions(listLimit: -1)),
         equals({
-          'a': {-1: 'b'}
+          'a': {'-1': 'b'}
         }),
       );
       expect(
         QS.decode('a[-1]=b', const DecodeOptions(listLimit: 0)),
         equals({
-          'a': {-1: 'b'}
+          'a': {'-1': 'b'}
         }),
       );
 
       expect(
         QS.decode('a[0]=b&a[1]=c', const DecodeOptions(listLimit: -1)),
         equals({
-          'a': {0: 'b', 1: 'c'}
+          'a': {'0': 'b', '1': 'c'}
         }),
       );
       expect(
         QS.decode('a[0]=b&a[1]=c', const DecodeOptions(listLimit: 0)),
         equals({
-          'a': {0: 'b', 1: 'c'}
+          'a': {'0': 'b', '1': 'c'}
         }),
       );
     });
@@ -989,7 +989,7 @@ void main() {
           const DecodeOptions(parseLists: false),
         ),
         equals({
-          'a': {0: 'b', 1: 'c'}
+          'a': {'0': 'b', '1': 'c'}
         }),
       );
       expect(
@@ -998,7 +998,7 @@ void main() {
           const DecodeOptions(parseLists: false),
         ),
         equals({
-          'a': {0: 'b'}
+          'a': {'0': 'b'}
         }),
       );
     });
@@ -1339,7 +1339,7 @@ void main() {
 
       final Map<String, dynamic> expectedlist = {};
       expectedlist['a'] = {};
-      expectedlist['a'][0] = 'b';
+      expectedlist['a']['0'] = 'b';
       expectedlist['a']['c'] = 'd';
       expect(
         QS.decode('a[]=b&a[c]=d'),

--- a/test/unit/utils_test.dart
+++ b/test/unit/utils_test.dart
@@ -182,8 +182,8 @@ void main() {
     group('merge', () {
       test('merges SplayTreeMap with List', () {
         expect(
-          Utils.merge({0: 'a'}, [const Undefined(), 'b']),
-          equals({0: 'a', 1: 'b'}),
+          Utils.merge({'0': 'a'}, [const Undefined(), 'b']),
+          equals({'0': 'a', '1': 'b'}),
         );
       });
 
@@ -369,8 +369,8 @@ void main() {
           equals(
             {
               'foo': {
-                0: 'bar',
-                1: {'first': '123'},
+                '0': 'bar',
+                '1': {'first': '123'},
                 'second': '456'
               }
             },
@@ -631,7 +631,7 @@ void main() {
           ),
           equals(
             {
-              'foo': {0: 'bar', 'baz': 'xyzzy'},
+              'foo': {'0': 'bar', 'baz': 'xyzzy'},
             },
           ),
         );
@@ -671,7 +671,7 @@ void main() {
           ),
           equals(
             {
-              'foo': {'bar': 'baz', 0: 'xyzzy'},
+              'foo': {'bar': 'baz', '0': 'xyzzy'},
             },
           ),
         );


### PR DESCRIPTION
## Description

`QS.decode` now decodes an `input` to `Map<String, dynamic>` instead of `Map<dynamic, dynamic>`. 

**NOTE:** This means that all decoded map keys will now be `String`s.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

The tests have been updated to reflect the change.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
