### PR TITLE
:bug: fix `QS.decode`: properly account for `strictNullHandling` when `allowEmptyLists`

### DIFF
--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -105,7 +105,8 @@ extension _$Decode on QS {
       final String root = chain[i];
 
       if (root == '[]' && options.parseLists) {
-        obj = options.allowEmptyLists && leaf == ''
+        obj = options.allowEmptyLists &&
+                (leaf == '' || (options.strictNullHandling && leaf == null))
             ? List<dynamic>.empty(growable: true)
             : [if (leaf is Iterable) ...leaf else leaf];
       } else {

--- a/test/unit/decode_test.dart
+++ b/test/unit/decode_test.dart
@@ -260,6 +260,22 @@ void main() {
       );
     });
 
+    test(
+      'allowEmptyLists + strictNullHandling',
+      () {
+        expect(
+          QS.decode(
+            'testEmptyList[]',
+            const DecodeOptions(
+              strictNullHandling: true,
+              allowEmptyLists: true,
+            ),
+          ),
+          equals({'testEmptyList': []}),
+        );
+      },
+    );
+
     test('parses a single nested string', () {
       expect(
         QS.decode('a[b]=c'),

--- a/test/unit/encode_test.dart
+++ b/test/unit/encode_test.dart
@@ -457,6 +457,22 @@ void main() {
       },
     );
 
+    test(
+      'allowEmptyLists + strictNullHandling',
+      () {
+        expect(
+          QS.encode(
+            {'testEmptyList': []},
+            const EncodeOptions(
+              strictNullHandling: true,
+              allowEmptyLists: true,
+            ),
+          ),
+          equals('testEmptyList[]'),
+        );
+      },
+    );
+
     group('encodes a list value with one item vs multiple items', () {
       test(
         'non-list item',


### PR DESCRIPTION
## Description

Fix `QS.decode` output when both `strictNullHandling` and `allowEmptyLists` are set to `true`.

Fixes https://github.com/ljharb/qs/issues/510

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added new tests.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
