### PR TITLE
:sparkles: DecodeOptions.strictDepth option to throw when input is beyond depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,25 @@ expect(
 );
 ```
 
+You can configure [decode] to throw an error when parsing nested input beyond this depth using
+[DecodeOptions.strictDepth] (defaults to false):
+
+```dart
+expect(
+  () => QS.decode(
+    'a[b][c][d][e][f][g][h][i]=j',
+    const DecodeOptions(
+      depth: 1,
+      strictDepth: true,
+    ),
+  ),
+  throwsA(isA<RangeError>()),
+);
+```
+
 The depth limit helps mitigate abuse when [decode] is used to parse user input, and it is recommended to keep it a
-reasonably small number.
+reasonably small number. [DecodeOptions.strictDepth] adds a layer of protection by throwing a [RangeError] when the
+limit is exceeded, allowing you to catch and handle such cases.
 
 For similar reasons, by default [decode] will only parse up to **1000** parameters. This can be overridden by passing 
 a [DecodeOptions.parameterLimit] option:

--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -190,8 +190,13 @@ extension _$Decode on QS {
       }
     }
 
-    // If there's a remainder, just add whatever is left
+    // If there's a remainder, check strictDepth option for throw, else just add whatever is left
     if (segment != null) {
+      if (options.strictDepth) {
+        throw RangeError(
+          'Input depth exceeded depth option of ${options.depth} and strictDepth is true',
+        );
+      }
       keys.add('[${key.slice(segment.start)}]');
     }
 

--- a/lib/src/models/decode_options.dart
+++ b/lib/src/models/decode_options.dart
@@ -24,6 +24,7 @@ final class DecodeOptions with EquatableMixin {
     this.interpretNumericEntities = false,
     this.parameterLimit = 1000,
     this.parseLists = true,
+    this.strictDepth = false,
     this.strictNullHandling = false,
   })  : allowDots = allowDots ?? decodeDotInKeys == true || false,
         decodeDotInKeys = decodeDotInKeys ?? false,
@@ -102,6 +103,10 @@ final class DecodeOptions with EquatableMixin {
   /// To disable [List] parsing entirely, set [parseLists] to `false`.
   final bool parseLists;
 
+  /// Set to `true` to add a layer of protection by throwing an error when the
+  /// limit is exceeded, allowing you to catch and handle such cases.
+  final bool strictDepth;
+
   /// Set to true to decode values without `=` to `null`.
   final bool strictNullHandling;
 
@@ -130,6 +135,7 @@ final class DecodeOptions with EquatableMixin {
     num? parameterLimit,
     bool? parseLists,
     bool? strictNullHandling,
+    bool? strictDepth,
     Decoder? decoder,
   }) =>
       DecodeOptions(
@@ -149,6 +155,7 @@ final class DecodeOptions with EquatableMixin {
         parameterLimit: parameterLimit ?? this.parameterLimit,
         parseLists: parseLists ?? this.parseLists,
         strictNullHandling: strictNullHandling ?? this.strictNullHandling,
+        strictDepth: strictDepth ?? this.strictDepth,
         decoder: decoder ?? _decoder,
       );
 
@@ -168,6 +175,7 @@ final class DecodeOptions with EquatableMixin {
       '  interpretNumericEntities: $interpretNumericEntities,\n'
       '  parameterLimit: $parameterLimit,\n'
       '  parseLists: $parseLists,\n'
+      '  strictDepth: $strictDepth,\n'
       '  strictNullHandling: $strictNullHandling\n'
       ')';
 
@@ -187,6 +195,7 @@ final class DecodeOptions with EquatableMixin {
         interpretNumericEntities,
         parameterLimit,
         parseLists,
+        strictDepth,
         strictNullHandling,
         _decoder,
       ];

--- a/test/unit/models/decode_options_test.dart
+++ b/test/unit/models/decode_options_test.dart
@@ -109,6 +109,7 @@ void main() {
         interpretNumericEntities: true,
         parameterLimit: 100,
         parseLists: false,
+        strictDepth: false,
         strictNullHandling: true,
       );
 
@@ -130,6 +131,7 @@ void main() {
           '  interpretNumericEntities: true,\n'
           '  parameterLimit: 100,\n'
           '  parseLists: false,\n'
+          '  strictDepth: false,\n'
           '  strictNullHandling: true\n'
           ')',
         ),


### PR DESCRIPTION
## Description

This PR adds `DecodeOptions.strictDepth` to enforce throwing when input depth is beyond the depth option.

Defaults to `false`.

Throws `RangeError`.

If depth has been set by the user to `0`, we do not throw, but fallback to the previous behaviour.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Added additional tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

---

Ref https://github.com/ljharb/qs/pull/511