### PR TITLE
:sparkles: decode: add throwOnLimitExceeded option qs#517

### DIFF
--- a/lib/src/extensions/extensions.dart
+++ b/lib/src/extensions/extensions.dart
@@ -1,14 +1,20 @@
 import 'dart:math' show min;
-import 'package:qs_dart/src/models/undefined.dart';
 
 extension IterableExtension<T> on Iterable<T> {
-  /// Returns a new [Iterable] without [Undefined] elements.
-  Iterable<T> whereNotUndefined() => where((T el) => el is! Undefined);
+  /// Returns a new [Iterable] without elements of type [Q].
+  Iterable<T> whereNotType<Q>() => where((T el) => el is! Q);
 }
 
 extension ListExtension<T> on List<T> {
-  /// Returns a new [List] without [Undefined] elements.
-  List<T> whereNotUndefined() => where((T el) => el is! Undefined).toList();
+  /// Extracts a section of a list and returns a new list.
+  ///
+  /// Modeled after JavaScript's `Array.prototype.slice()` method.
+  /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
+  List<T> slice([int start = 0, int? end]) => sublist(
+        (start < 0 ? length + start : start).clamp(0, length),
+        (end == null ? length : (end < 0 ? length + end : end))
+            .clamp(0, length),
+      );
 }
 
 extension StringExtension on String {

--- a/lib/src/models/decode_options.dart
+++ b/lib/src/models/decode_options.dart
@@ -26,6 +26,7 @@ final class DecodeOptions with EquatableMixin {
     this.parseLists = true,
     this.strictDepth = false,
     this.strictNullHandling = false,
+    this.throwOnLimitExceeded = false,
   })  : allowDots = allowDots ?? decodeDotInKeys == true || false,
         decodeDotInKeys = decodeDotInKeys ?? false,
         _decoder = decoder,
@@ -109,6 +110,9 @@ final class DecodeOptions with EquatableMixin {
 
   /// Set to true to decode values without `=` to `null`.
   final bool strictNullHandling;
+
+  /// Set to `true` to throw an error when the limit is exceeded.
+  final bool throwOnLimitExceeded;
 
   /// Set a [Decoder] to affect the decoding of the input.
   final Decoder? _decoder;

--- a/lib/src/qs.dart
+++ b/lib/src/qs.dart
@@ -1,6 +1,7 @@
 import 'dart:convert' show latin1, utf8, Encoding;
 import 'dart:typed_data' show ByteBuffer;
 
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:qs_dart/src/enums/duplicates.dart';
 import 'package:qs_dart/src/enums/format.dart';
 import 'package:qs_dart/src/enums/list_format.dart';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -42,11 +42,14 @@ final class Utils {
             target_[target_.length] = source;
           }
 
-          if (target is Set) {
-            target = target_.values.whereNotUndefined().toSet();
-          } else {
-            target = target_.values.whereNotUndefined().toList();
-          }
+          target = target_.values.any((el) => el is Undefined)
+              ? SplayTreeMap.from({
+                  for (final MapEntry<int, dynamic> entry in target_.entries)
+                    if (entry.value is! Undefined) entry.key: entry.value,
+                })
+              : target is Set
+                  ? target_.values.toSet()
+                  : target_.values.toList();
         } else {
           if (source is Iterable) {
             // check if source is a list of maps and target is a list of maps
@@ -70,9 +73,11 @@ final class Utils {
               }
             } else {
               if (target is Set) {
-                target = Set.of(target)..addAll(source.whereNotUndefined());
+                target = Set.of(target)
+                  ..addAll(source.whereNotType<Undefined>());
               } else {
-                target = List.of(target)..addAll(source.whereNotUndefined());
+                target = List.of(target)
+                  ..addAll(source.whereNotType<Undefined>());
               }
             }
           } else if (source != null) {
@@ -96,7 +101,7 @@ final class Utils {
         }
       } else if (source != null) {
         if (target is! Iterable && source is Iterable) {
-          return [target, ...source.whereNotUndefined()];
+          return [target, ...source.whereNotType<Undefined>()];
         }
         return [target, source];
       }
@@ -115,11 +120,11 @@ final class Utils {
 
       return [
         if (target is Iterable)
-          ...target.whereNotUndefined()
+          ...target.whereNotType<Undefined>()
         else if (target != null)
           target,
         if (source is Iterable)
-          ...(source as Iterable).whereNotUndefined()
+          ...(source as Iterable).whereNotType<Undefined>()
         else
           source,
       ];
@@ -381,9 +386,9 @@ final class Utils {
 
       if (obj is Iterable) {
         if (obj is Set) {
-          item['obj'][item['prop']] = obj.whereNotUndefined().toSet();
+          item['obj'][item['prop']] = obj.whereNotType<Undefined>().toSet();
         } else {
-          item['obj'][item['prop']] = obj.whereNotUndefined().toList();
+          item['obj'][item['prop']] = obj.whereNotType<Undefined>().toList();
         }
       }
     }

--- a/test/unit/decode_test.dart
+++ b/test/unit/decode_test.dart
@@ -412,7 +412,7 @@ void main() {
       expect(
         QS.decode('a[1]=b&a=c', const DecodeOptions(listLimit: 20)),
         equals({
-          'a': ['b', 'c']
+          'a': {1: 'b', 2: 'c'}
         }),
       );
       expect(
@@ -818,7 +818,7 @@ void main() {
       expect(
         QS.decode('a[10]=1&a[2]=2', const DecodeOptions(listLimit: 20)),
         equals({
-          'a': ['2', '1']
+          'a': {2: '2', 10: '1'}
         }),
       );
       expect(
@@ -1767,5 +1767,91 @@ void main() {
         );
       },
     );
+  });
+
+  group('parameter limit', () {
+    test('does not throw error when within parameter limit', () {
+      expect(
+        QS.decode('a=1&b=2&c=3',
+            const DecodeOptions(parameterLimit: 5, throwOnLimitExceeded: true)),
+        equals({'a': '1', 'b': '2', 'c': '3'}),
+      );
+    });
+
+    test('throws error when parameter limit exceeded', () {
+      expect(
+        () => QS.decode(
+          'a=1&b=2&c=3&d=4&e=5&f=6',
+          const DecodeOptions(parameterLimit: 3, throwOnLimitExceeded: true),
+        ),
+        throwsA(isA<RangeError>()),
+      );
+    });
+
+    test('silently truncates when throwOnLimitExceeded is not given', () {
+      expect(
+        QS.decode(
+          'a=1&b=2&c=3&d=4&e=5',
+          const DecodeOptions(parameterLimit: 3),
+        ),
+        equals({'a': '1', 'b': '2', 'c': '3'}),
+      );
+    });
+
+    test('silently truncates when parameter limit exceeded without error', () {
+      expect(
+        QS.decode(
+          'a=1&b=2&c=3&d=4&e=5',
+          const DecodeOptions(parameterLimit: 3, throwOnLimitExceeded: false),
+        ),
+        equals({'a': '1', 'b': '2', 'c': '3'}),
+      );
+    });
+
+    test('allows unlimited parameters when parameterLimit set to Infinity', () {
+      expect(
+        QS.decode(
+          'a=1&b=2&c=3&d=4&e=5&f=6',
+          const DecodeOptions(parameterLimit: double.infinity),
+        ),
+        equals({'a': '1', 'b': '2', 'c': '3', 'd': '4', 'e': '5', 'f': '6'}),
+      );
+    });
+  });
+
+  group('list limit tests', () {
+    test('does not throw error when list is within limit', () {
+      expect(
+        QS.decode(
+          'a[]=1&a[]=2&a[]=3',
+          const DecodeOptions(listLimit: 5, throwOnLimitExceeded: true),
+        ),
+        equals({
+          'a': ['1', '2', '3']
+        }),
+      );
+    });
+
+    test('throws error when list limit exceeded', () {
+      expect(
+        () => QS.decode(
+          'a[]=1&a[]=2&a[]=3&a[]=4',
+          const DecodeOptions(listLimit: 3, throwOnLimitExceeded: true),
+        ),
+        throwsA(isA<RangeError>()),
+      );
+    });
+
+    test('converts list to map if length is greater than limit', () {
+      expect(
+        QS.decode(
+          'a[1]=1&a[2]=2&a[3]=3&a[4]=4&a[5]=5&a[6]=6',
+          const DecodeOptions(listLimit: 5),
+        ),
+        equals({
+          'a': {'1': '1', '2': '2', '3': '3', '4': '4', '5': '5', '6': '6'}
+        }),
+      );
+    });
   });
 }

--- a/test/unit/extensions/extensions_test.dart
+++ b/test/unit/extensions/extensions_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('IterableExtension', () {
     test('whereNotUndefined', () {
       const Iterable<dynamic> iterable = [1, 2, Undefined(), 4, 5];
-      final Iterable<dynamic> result = iterable.whereNotUndefined();
+      final Iterable<dynamic> result = iterable.whereNotType<Undefined>();
       expect(result, isA<Iterable<dynamic>>());
       expect(result, [1, 2, 4, 5]);
     });
@@ -15,9 +15,25 @@ void main() {
   group('ListExtension', () {
     test('whereNotUndefined', () {
       const List<dynamic> list = [1, 2, Undefined(), 4, 5];
-      final List<dynamic> result = list.whereNotUndefined();
+      final List<dynamic> result = list.whereNotType<Undefined>().toList();
       expect(result, isA<List<dynamic>>());
       expect(result, [1, 2, 4, 5]);
+    });
+
+    test('slice', () {
+      const List<String> animals = [
+        'ant',
+        'bison',
+        'camel',
+        'duck',
+        'elephant',
+      ];
+      expect(animals.slice(2), ['camel', 'duck', 'elephant']);
+      expect(animals.slice(2, 4), ['camel', 'duck']);
+      expect(animals.slice(1, 5), ['bison', 'camel', 'duck', 'elephant']);
+      expect(animals.slice(-2), ['duck', 'elephant']);
+      expect(animals.slice(2, -1), ['camel', 'duck']);
+      expect(animals.slice(), ['ant', 'bison', 'camel', 'duck', 'elephant']);
     });
   });
 

--- a/test/unit/uri_extension_test.dart
+++ b/test/unit/uri_extension_test.dart
@@ -439,7 +439,7 @@ void main() {
         Uri.parse('$testUrl?a[1]=b&a=c')
             .queryParametersQs(const DecodeOptions(listLimit: 20)),
         equals({
-          'a': ['b', 'c']
+          'a': {1: 'b', 2: 'c'}
         }),
       );
       expect(
@@ -864,7 +864,7 @@ void main() {
         Uri.parse('$testUrl?a[10]=1&a[2]=2')
             .queryParametersQs(const DecodeOptions(listLimit: 20)),
         equals({
-          'a': ['2', '1']
+          'a': {2: '2', 10: '1'}
         }),
       );
       expect(


### PR DESCRIPTION
## Description

This pull request includes significant changes to the `qs_dart` package, primarily focusing on improving the handling of list and parameter limits, as well as enhancing utility methods. The key changes include the introduction of error handling for exceeding list and parameter limits, updates to utility methods, and modifications to test cases to reflect these updates.

### Handling Limits:
* Added error handling for exceeding list and parameter limits in the `DecodeOptions` class and related methods (`lib/src/extensions/decode.dart`, `lib/src/models/decode_options.dart`). [[1]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL11-R29) [[2]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL26-R57) [[3]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081R29) [[4]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081R114-R116)

### Utility Method Updates:
* Updated utility methods to use a more generic approach for filtering out elements of a specific type (`lib/src/extensions/extensions.dart`, `lib/src/utils.dart`). [[1]](diffhunk://#diff-2b16857bf62effbb9d643290f59896b11963292f56728e5b78facc9060c561a8L2-R17) [[2]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL45-R52) [[3]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL73-R80) [[4]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL99-R104) [[5]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL118-R127) [[6]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL384-R391)

### Test Case Modifications:
* Modified existing test cases and added new ones to validate the new error handling and utility method changes (`test/unit/decode_test.dart`, `test/unit/extensions/extensions_test.dart`, `test/unit/uri_extension_test.dart`). [[1]](diffhunk://#diff-3aeb6a83c72aa3aa12fee23fa065497711a393eb9833add4ab7b0b60cf37e6a0L415-R415) [[2]](diffhunk://#diff-3aeb6a83c72aa3aa12fee23fa065497711a393eb9833add4ab7b0b60cf37e6a0L821-R821) [[3]](diffhunk://#diff-3aeb6a83c72aa3aa12fee23fa065497711a393eb9833add4ab7b0b60cf37e6a0R1771-R1856) [[4]](diffhunk://#diff-f3d1a1e2be3bb8e7c4700f7adb558d98adc5d35ad5539916a7e82c383c892e2dL9-R9) [[5]](diffhunk://#diff-f3d1a1e2be3bb8e7c4700f7adb558d98adc5d35ad5539916a7e82c383c892e2dL18-R37) [[6]](diffhunk://#diff-571d1379ff29eb519ca31b13cbe02e274c61ec54855b782a7316e5ec1149a0ddL442-R442) [[7]](diffhunk://#diff-571d1379ff29eb519ca31b13cbe02e274c61ec54855b782a7316e5ec1149a0ddL867-R867)

### Additional Imports:
* Added necessary imports for new functionalities (`lib/src/qs.dart`).

Fixes #(issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added new tests

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
