### PR TITLE
:bug: fix decode dot in keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install:
 
 sure:
 	@# Help: Analyze the project's Dart code, check the formatting one or more Dart files and run unit tests for the current project.
-	make check_style && make tests
+	make check_style && make test
 
 show_test_coverage:
 	@# Help: Run Dart unit tests for the current project and show the coverage.

--- a/lib/qs_dart.dart
+++ b/lib/qs_dart.dart
@@ -19,6 +19,7 @@
 /// See the repository README for complete examples and edge‑case notes.
 library;
 
+export 'src/enums/decode_kind.dart';
 export 'src/enums/duplicates.dart';
 export 'src/enums/format.dart';
 export 'src/enums/list_format.dart';

--- a/lib/src/enums/decode_kind.dart
+++ b/lib/src/enums/decode_kind.dart
@@ -1,0 +1,36 @@
+/// Decoding context used by the query string parser and utilities.
+///
+/// This enum indicates whether a piece of text is being decoded as a **key**
+/// (or key segment) or as a **value**. The distinction matters for
+/// percent‑encoded dots (`%2E` / `%2e`) that appear **in keys**:
+///
+/// * When decoding **keys**, implementations often *preserve* encoded dots so
+///   higher‑level options like `allowDots` and `decodeDotInKeys` can be applied
+///   consistently during key‑splitting.
+/// * When decoding **values**, implementations typically perform full percent
+///   decoding.
+///
+/// ### Usage
+///
+/// ```dart
+/// import 'decode_kind.dart';
+///
+/// DecodeKind k = DecodeKind.key; // decode a key/segment
+/// DecodeKind v = DecodeKind.value; // decode a value
+/// ```
+///
+/// ### Notes
+///
+/// Prefer identity comparisons with enum members (e.g. `kind == DecodeKind.key`).
+/// The underlying `name`/`index` are implementation details and should not be
+/// relied upon for logic.
+enum DecodeKind {
+  /// Decode a **key** (or key segment). Implementations may preserve
+  /// percent‑encoded dots (`%2E` / `%2e`) so that dot‑splitting semantics can be
+  /// applied later according to parser options.
+  key,
+
+  /// Decode a **value**. Implementations typically perform full percent
+  /// decoding.
+  value,
+}

--- a/lib/src/qs.dart
+++ b/lib/src/qs.dart
@@ -1,6 +1,7 @@
 import 'dart:convert' show latin1, utf8, Encoding;
 import 'dart:typed_data' show ByteBuffer;
 
+import 'package:qs_dart/src/enums/decode_kind.dart';
 import 'package:qs_dart/src/enums/duplicates.dart';
 import 'package:qs_dart/src/enums/format.dart';
 import 'package:qs_dart/src/enums/list_format.dart';
@@ -11,6 +12,9 @@ import 'package:qs_dart/src/models/encode_options.dart';
 import 'package:qs_dart/src/models/undefined.dart';
 import 'package:qs_dart/src/utils.dart';
 import 'package:weak_map/weak_map.dart';
+
+// Re-export for public API: consumers can `import 'package:qs_dart/qs.dart'` and access DecodeKind
+export 'package:qs_dart/src/enums/decode_kind.dart';
 
 part 'extensions/decode.dart';
 part 'extensions/encode.dart';
@@ -65,8 +69,10 @@ final class QS {
         : input;
 
     // Guardrail: if the top-level parameter count is large, temporarily disable
-    // list parsing to keep memory bounded (matches Node `qs`).
-    if (options.parseLists &&
+    // list parsing to keep memory bounded (matches Node `qs`). Only apply for
+    // raw string inputs, not for pre-tokenized maps.
+    if (input is String &&
+        options.parseLists &&
         options.listLimit > 0 &&
         (tempObj?.length ?? 0) > options.listLimit) {
       options = options.copyWith(parseLists: false);

--- a/test/unit/decode_test.dart
+++ b/test/unit/decode_test.dart
@@ -2014,4 +2014,203 @@ void main() {
       );
     });
   });
+
+  group('key-aware decoder + options isolation', () {
+    test('custom decoder receives kind for keys and values', () {
+      final kinds = <DecodeKind>[];
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        kinds.add(kind ?? DecodeKind.value);
+        return Utils.decode(v, charset: charset);
+      }
+
+      expect(QS.decode('a=b&c=d', DecodeOptions(decoder: dec)), {
+        'a': 'b',
+        'c': 'd',
+      });
+
+      expect(kinds, [
+        DecodeKind.key, DecodeKind.value, // a=b
+        DecodeKind.key, DecodeKind.value, // c=d
+      ]);
+    });
+
+    test('legacy single-arg decoder still works', () {
+      String? dec(String? v) => v?.toUpperCase();
+      expect(QS.decode('a=b', DecodeOptions(decoder: dec)), {'A': 'B'});
+    });
+
+    test('decoder that only accepts kind also works', () {
+      dynamic dec(String? v, {DecodeKind? kind}) =>
+          kind == DecodeKind.key ? v?.toUpperCase() : v;
+
+      expect(QS.decode('aa=bb', DecodeOptions(decoder: dec)), {'AA': 'bb'});
+    });
+
+    test('parseLists toggle does not leak across calls (string input)', () {
+      // Build a query with many top-level params to trigger the internal guardrail
+      final bigQuery = List.generate(25, (i) => 'k$i=v$i').join('&');
+      final opts = const DecodeOptions(listLimit: 20);
+
+      final res1 = QS.decode(bigQuery, opts);
+      expect(res1.length, 25);
+
+      // The same options instance should still parse lists on the next call
+      final res2 = QS.decode('a[]=1&a[]=2', opts);
+      expect(res2, {
+        'a': ['1', '2']
+      });
+    });
+  });
+
+  group('DecodeKind scenarios', () {
+    test('uses KEY for bare key without = (strictNullHandling true)', () {
+      final kinds = <DecodeKind>[];
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        kinds.add(kind ?? DecodeKind.value);
+        return Utils.decode(v, charset: charset);
+      }
+
+      final res = QS.decode(
+          'foo', DecodeOptions(strictNullHandling: true, decoder: dec));
+      expect(res, {'foo': null});
+      expect(kinds, [DecodeKind.key]);
+    });
+
+    test('comma-split invokes VALUE for each segment', () {
+      final kinds = <DecodeKind>[];
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        kinds.add(kind ?? DecodeKind.value);
+        return Utils.decode(v, charset: charset);
+      }
+
+      final res = QS.decode('a=b,c', DecodeOptions(comma: true, decoder: dec));
+      expect(res, {
+        'a': ['b', 'c']
+      });
+      // Order: key, value(b), value(c)
+      expect(kinds, [DecodeKind.key, DecodeKind.value, DecodeKind.value]);
+    });
+
+    test('custom decoder can mutate keys only (KEY) without touching values',
+        () {
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        if (kind == DecodeKind.key) return v?.toUpperCase();
+        return v;
+      }
+
+      expect(QS.decode('a=b&c=d', DecodeOptions(decoder: dec)), {
+        'A': 'b',
+        'C': 'd',
+      });
+    });
+
+    test('custom decoder returning null for VALUE preserves null in result',
+        () {
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        if (kind == DecodeKind.value) return null;
+        return v;
+      }
+
+      expect(QS.decode('a=b', DecodeOptions(decoder: dec)), {'a': null});
+    });
+
+    test('decoder is not invoked for Map input', () {
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        throw StateError('decoder should not be called for Map input');
+      }
+
+      final input = {'a': 'b'};
+      expect(QS.decode(input, DecodeOptions(decoder: dec)), equals(input));
+    });
+
+    test('duplicates=combine yields KEY,VALUE per pair', () {
+      final kinds = <DecodeKind>[];
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        kinds.add(kind ?? DecodeKind.value);
+        return v;
+      }
+
+      final res = QS.decode('foo=bar&foo=baz', DecodeOptions(decoder: dec));
+      expect(res, {
+        'foo': ['bar', 'baz']
+      });
+      expect(kinds, [
+        DecodeKind.key, DecodeKind.value, // first
+        DecodeKind.key, DecodeKind.value, // second
+      ]);
+    });
+
+    test('charset sentinel switches charset observed by decoder', () {
+      final seen = <Encoding?>[];
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        seen.add(charset);
+        return v; // pass through
+      }
+
+      // Numeric entity sentinel implies latin1
+      final res = QS.decode(
+        'utf8=%26%2310003%3B&x=%C3%B8',
+        DecodeOptions(charsetSentinel: true, charset: utf8, decoder: dec),
+      );
+      expect(res, contains('x'));
+      // We expect at least one latin1 observation (for the x pair after sentinel)
+      expect(seen.any((e) => e == latin1), isTrue);
+    });
+
+    test('parseLists=false still passes KEY for keys and VALUE for values', () {
+      final kinds = <DecodeKind>[];
+      dynamic dec(String? v, {Encoding? charset, DecodeKind? kind}) {
+        kinds.add(kind ?? DecodeKind.value);
+        return v;
+      }
+
+      final res =
+          QS.decode('a[0]=b', DecodeOptions(parseLists: false, decoder: dec));
+      expect(res, {
+        'a': {'0': 'b'}
+      });
+      expect(kinds, [DecodeKind.key, DecodeKind.value]);
+    });
+  });
+
+  group('decoder dynamic fallback', () {
+    test(
+        'callable object with mismatching named params falls back to (value) only',
+        () {
+      final calls = <String?>[];
+      // A callable object whose named parameters do not match the library typedefs.
+      final res = QS.decode('a=b', DecodeOptions(decoder: _Loose1(calls)));
+      // Since the dynamic path ends up invoking `(value)` with no named args,
+      // both key and value get prefixed with 'X'.
+      expect(res, {'Xa': 'Xb'});
+      expect(calls, ['a', 'b']);
+    });
+
+    test(
+        'callable object with a required named param triggers Utils.decode fallback',
+        () {
+      final res = QS.decode('a=b', DecodeOptions(decoder: _Loose2()));
+      expect(res, {'a': 'b'});
+    });
+  });
+}
+
+// Helper callable used to exercise the dynamic function fallback in DecodeOptions.decoder.
+// Named parameters intentionally do not match `charset`/`kind` so the typed branches
+// are skipped and the dynamic ladder is exercised.
+class _Loose1 {
+  final List<String?> sink;
+
+  _Loose1(this.sink);
+
+  dynamic call(String? v, {Encoding? cs, DecodeKind? kd}) {
+    sink.add(v);
+    return v == null ? null : 'X$v';
+  }
+}
+
+// Helper callable that requires an unsupported named parameter; all dynamic attempts
+// should throw, causing the code to fall back to Utils.decode.
+class _Loose2 {
+  dynamic call(String? v, {required int must}) => 'Y$v';
 }


### PR DESCRIPTION
This pull request introduces key-aware decoding to the query string parser, allowing custom decoders to distinguish between keys and values when parsing, and adds robust support for various custom decoder signatures. It also improves percent-decoding of dots in keys, refines guardrails for large query strings, and adds comprehensive tests for the new decoding logic and option isolation.

### Key-aware decoding and custom decoder support

* Added a new `DecodeKind` enum to distinguish between decoding keys and values, and updated the decoder API to pass this context to custom decoders. This allows for more precise handling, such as preserving encoded dots in keys. (`lib/src/enums/decode_kind.dart`, `lib/qs_dart.dart`, `lib/src/models/decode_options.dart`, `lib/src/extensions/decode.dart`, `lib/src/qs.dart`) [[1]](diffhunk://#diff-b55e71de82638a97890891af6811a312fa40ff183008497cd51139e420fa2286R1-R36) [[2]](diffhunk://#diff-13f1a17cf7bfe6a6478e783d2bce85ab0cb6bc065d22c017d022a0e88db36c78R22) [[3]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081R4) [[4]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081L30-R55) [[5]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081L159-R212) [[6]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081L185-R232) [[7]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL148-R156) [[8]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL163-R167) [[9]](diffhunk://#diff-fc15cd5125f0f977fbacf20e0d73ce7b9ec7e88870c3370c67c96b245512659aR4) [[10]](diffhunk://#diff-fc15cd5125f0f977fbacf20e0d73ce7b9ec7e88870c3370c67c96b245512659aR16-R18)
* Enhanced `DecodeOptions` to accept multiple decoder function signatures, including legacy and new forms, with a dynamic fallback mechanism for callable objects. (`lib/src/models/decode_options.dart`) [[1]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081L30-R55) [[2]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081L159-R212) [[3]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081L185-R232)

### Decoding improvements

* Improved percent-decoding for dots in keys by handling both `%2E` and `%2e` consistently when `decodeDotInKeys` is enabled. (`lib/src/extensions/decode.dart`)
* Updated the decoding logic to use `DecodeKind.key` for keys and `DecodeKind.value` for values, including bare keys and comma-split values. (`lib/src/extensions/decode.dart`) [[1]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL148-R156) [[2]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL163-R167)

### Guardrail and option isolation

* Refined the guardrail for large query strings to only disable list parsing for raw string inputs, ensuring options isolation and preventing leakage across calls. (`lib/src/qs.dart`)

### Testing and validation

* Added extensive unit tests for key-aware decoding, custom decoder signatures, percent-decoding of dots, option isolation, and dynamic decoder fallback logic. (`test/unit/decode_test.dart`)

### Miscellaneous

* Updated the `Makefile` to use the correct test target (`make test` instead of `make tests`). (`Makefile`)