### PR TITLE
:bug: protect encoded dots in keys during decoding when decodeDotInKeys is false

### DIFF
--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -273,7 +273,7 @@ extension _$Decode on QS {
             ? root.slice(1, root.length - 1)
             : root;
         final String decodedRoot = options.decodeDotInKeys
-            ? cleanRoot.replaceAll('%2E', '.')
+            ? cleanRoot.replaceAll('%2E', '.').replaceAll('%2e', '.')
             : cleanRoot;
         final int? index = int.tryParse(decodedRoot);
         if (!options.parseLists && decodedRoot == '') {
@@ -316,7 +316,7 @@ extension _$Decode on QS {
 
     final segments = _splitKeyIntoSegments(
       originalKey: givenKey,
-      allowDots: options.allowDots,
+      allowDots: options.allowDots || options.decodeDotInKeys,
       maxDepth: options.depth,
       strictDepth: options.strictDepth,
     );

--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -147,11 +147,9 @@ extension _$Decode on QS {
       dynamic val;
       // Bare key without '=', interpret as null vs empty-string per strictNullHandling.
       if (pos == -1) {
-        // Protect %2E/%2e in keys so dot-splitting doesn’t see them unless decodeDotInKeys is true.
+        // Protect %2E/%2e in keys so dot-splitting never sees them as literal dots.
         String keyInput = part;
-        if (options.allowDots &&
-            !options.decodeDotInKeys &&
-            keyInput.contains('%2')) {
+        if (options.allowDots && keyInput.contains('%2')) {
           keyInput =
               keyInput.replaceAll('%2E', '%252E').replaceAll('%2e', '%252e');
         }
@@ -160,9 +158,7 @@ extension _$Decode on QS {
       } else {
         // Protect %2E/%2e in the key slice only; values decode normally.
         String keyInput = part.slice(0, pos);
-        if (options.allowDots &&
-            !options.decodeDotInKeys &&
-            keyInput.contains('%2')) {
+        if (options.allowDots && keyInput.contains('%2')) {
           keyInput =
               keyInput.replaceAll('%2E', '%252E').replaceAll('%2e', '%252e');
         }
@@ -316,7 +312,7 @@ extension _$Decode on QS {
 
     final segments = _splitKeyIntoSegments(
       originalKey: givenKey,
-      allowDots: options.allowDots || options.decodeDotInKeys,
+      allowDots: options.allowDots,
       maxDepth: options.depth,
       strictDepth: options.strictDepth,
     );


### PR DESCRIPTION
This pull request updates the decoding logic in the `extension _$Decode on QS` within `lib/src/extensions/decode.dart` to improve how percent-encoded dots (`%2E`/`%2e`) are handled in query string keys, particularly when dot splitting is enabled but decoding of dots in keys is not desired. The main change protects encoded dots from being prematurely interpreted as key separators, ensuring more accurate parsing.

Key improvements to query string key decoding:

* Added logic to detect `%2E`/`%2e` in keys and replace them with `%252E`/`%252e` when `allowDots` is true and `decodeDotInKeys` is false, preventing accidental dot splitting during decoding.
* Applied this protection both for bare keys and for keys with values (i.e., before the `=` sign), ensuring consistent behavior in all parsing scenarios.