### PR TITLE
:sparkles: enhance decoding options and tests for strict merge behavior, bracket notation, and list limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.7.5-dev
 
+* [FEAT] add `DecodeOptions.strictMerge` for Node `qs` `strictMerge` parity, defaulting to object/scalar array wrapping while supporting legacy scalar-key merge mode
+* [FIX] match Node `qs` 6.14.2 list-limit semantics for indexed notation, comma-list overflow, and mixed overflow maps
+* [FIX] match Node `qs` 6.15.0 duplicate handling so bracket notation combines regardless of the selected duplicate strategy
+* [FIX] preserve unlimited parsing with `parameterLimit: double.infinity` and `throwOnLimitExceeded: true`
 * [FIX] match Node `qs` 6.15.2 bracket parsing behavior for nested/literal bracket groups, encoded bracket text, and `allowDots` with `depth: 0`
 * [FIX] match Node `qs` 6.15.2 stringify edge cases for charset sentinel delimiters, strict-null RFC1738 formatting, comma-list null slots, and null filter entries
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,21 @@ expect(
 );
 ```
 
+Bracket notation combines regardless of [DecodeOptions.duplicates]:
+
+```dart
+expect(
+  QS.decode(
+    'a=1&a=2&b[]=1&b[]=2',
+    const DecodeOptions(duplicates: Duplicates.last),
+  ),
+  equals({
+    'a': '2',
+    'b': ['1', '2'],
+  }),
+);
+```
+
 If you have to deal with legacy browsers or services, there's also support for decoding percent-encoded octets as
 [latin1]:
 
@@ -468,14 +483,17 @@ This limit can be overridden by passing an [DecodeOptions.listLimit] option:
 ```dart
 expect(
   QS.decode(
-    'a[1]=b',
+    'a[0]=b',
     const DecodeOptions(listLimit: 0),
   ),
   equals({
-    'a': {'1': 'b'}
+    'a': {'0': 'b'}
   }),
 );
 ```
+
+[DecodeOptions.listLimit] is a maximum element count. With the default limit of
+20, `a[19]=b` can still become a [List], while `a[20]=b` falls back to a [Map].
 
 To disable List parsing entirely, set [DecodeOptions.parseLists] to `false`.
 
@@ -498,6 +516,35 @@ expect(
   QS.decode('a[0]=b&a[b]=c'),
   equals({
     'a': {'0': 'b', 'b': 'c'}
+  }),
+);
+```
+
+When a key appears as both an object and a scalar, [DecodeOptions.strictMerge]
+wraps the conflict in a [List] by default:
+
+```dart
+expect(
+  QS.decode('a[b]=c&a=d'),
+  equals({
+    'a': [
+      {'b': 'c'},
+      'd',
+    ]
+  }),
+);
+```
+
+Set `strictMerge: false` to restore legacy scalar-key merge behavior:
+
+```dart
+expect(
+  QS.decode(
+    'a[b]=c&a=d',
+    const DecodeOptions(strictMerge: false),
+  ),
+  equals({
+    'a': {'b': 'c', 'd': true}
   }),
 );
 ```

--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -37,10 +37,8 @@ extension _$Decode on QS {
   ///
   /// **Negative `listLimit` semantics:** a negative value disables numeric-index parsing
   /// elsewhere (e.g. `[2]` segments become string keys). For comma‑splits specifically:
-  /// when `throwOnLimitExceeded` is `true` and `listLimit < 0`, any non‑empty split throws
-  /// immediately; when `false`, growth is effectively capped at zero (the split produces
-  /// an empty list). Empty‑bracket pushes (`a[]=`) are handled during structure building
-  /// in `_parseObject`.
+  /// over-limit values are promoted after value decoding, so all split values are
+  /// preserved unless `throwOnLimitExceeded` is `true`.
   static dynamic _parseListValue(
     final dynamic val,
     final DecodeOptions options,
@@ -49,24 +47,7 @@ extension _$Decode on QS {
   ) {
     // Fast-path: split comma-separated scalars into a list when requested.
     if (val is String && val.isNotEmpty && options.comma && val.contains(',')) {
-      final int remaining = options.listLimit - currentListLength;
-
-      if (options.throwOnLimitExceeded) {
-        if (remaining < 0) {
-          throw RangeError(_listLimitExceededMessage(options.listLimit));
-        }
-        final List<String> splitVal = _splitCommaValue(
-          val,
-          maxParts: remaining == 0 ? 1 : remaining + 1,
-        );
-        if (splitVal.length > remaining) {
-          throw RangeError(_listLimitExceededMessage(options.listLimit));
-        }
-        return splitVal;
-      }
-
-      if (remaining <= 0) return const <String>[];
-      return _splitCommaValue(val, maxParts: remaining);
+      return _splitCommaValue(val);
     }
 
     // Guard incremental growth of an existing list as we parse additional items.
@@ -85,6 +66,21 @@ extension _$Decode on QS {
       ? 'List parsing is disabled (listLimit < 0).'
       : 'List limit exceeded. Only $listLimit '
           'element${listLimit == 1 ? '' : 's'} allowed in a list.';
+
+  /// Applies comma-list limit handling after values have been decoded and
+  /// after `[]` suffix wrapping, matching Node `qs` ordering.
+  static dynamic _promoteCommaListIfNeeded(
+    final dynamic val,
+    final DecodeOptions options,
+  ) {
+    if (!options.comma || val is! Iterable || val.length <= options.listLimit) {
+      return val;
+    }
+    if (options.throwOnLimitExceeded) {
+      throw RangeError(_listLimitExceededMessage(options.listLimit));
+    }
+    return Utils.combine([], val, listLimit: options.listLimit);
+  }
 
   /// Splits a comma-separated value into parts, respecting an optional `maxParts` limit.
   static List<String> _splitCommaValue(
@@ -276,13 +272,15 @@ extension _$Decode on QS {
         key = options.decodeKey(rawKey, charset: charset) ?? '';
         // Decode the substring *after* '=', applying list parsing and the configured decoder.
         final bool existingKey = obj.containsKey(key);
+        final bool bracketSuffix = options.parseLists && rawKey.endsWith('[]');
         final bool combiningDuplicates =
             existingKey && options.duplicates == Duplicates.combine;
-        final int currentListLength = combiningDuplicates
-            ? (obj[key] is List ? (obj[key] as List).length : 1)
-            : 0;
-        final bool listGrowthFromKey = combiningDuplicates ||
-            (options.parseLists && rawKey.endsWith('[]'));
+        final dynamic existingValue = obj[key];
+        final int currentListLength =
+            combiningDuplicates && existingValue is Iterable
+                ? existingValue.length
+                : 0;
+        final bool listGrowthFromKey = combiningDuplicates || bracketSuffix;
 
         val = Utils.apply<dynamic>(
           _parseListValue(
@@ -310,17 +308,25 @@ extension _$Decode on QS {
       }
 
       // Quirk: a key ending in `[]` forces an array container (qs behavior).
-      if (options.parseLists &&
+      final bool bracketSuffix = options.parseLists &&
           pos != -1 &&
-          part.substring(0, pos).endsWith('[]')) {
+          part.substring(0, pos).endsWith('[]');
+      if (bracketSuffix && val is Iterable) {
         val = [val];
       }
+
+      val = _promoteCommaListIfNeeded(val, options);
 
       // Duplicate key policy: combine/first/last (default: combine).
       final bool existing = obj.containsKey(key);
       switch ((existing, options.duplicates)) {
         case (true, Duplicates.combine):
           // Existing key + `combine` policy: merge old/new values.
+          obj[key] = Utils.combine(obj[key], val, listLimit: options.listLimit);
+          break;
+        case (true, _) when bracketSuffix:
+          // `qs` always combines duplicate bracket-notation keys, even when
+          // the duplicates option is `first` or `last`.
           obj[key] = Utils.combine(obj[key], val, listLimit: options.listLimit);
           break;
         case (false, _):
@@ -434,13 +440,13 @@ extension _$Decode on QS {
         final int? index = (wasBracketed && options.parseLists)
             ? int.tryParse(decodedRoot)
             : null;
-        if (!options.parseLists && decodedRoot == '') {
-          obj = <String, dynamic>{'0': leaf};
-        } else if (index != null &&
+        final bool isValidListIndex = index != null &&
             index >= 0 &&
             index.toString() == decodedRoot &&
-            options.parseLists &&
-            index <= options.listLimit) {
+            options.parseLists;
+        if (!options.parseLists && decodedRoot == '') {
+          obj = <String, dynamic>{'0': leaf};
+        } else if (isValidListIndex && index < options.listLimit) {
           // Numeric segment treated as list index when lists are enabled and the
           // token was actually bracketed (to disambiguate bare numeric keys).
           obj = List<dynamic>.filled(
@@ -449,6 +455,11 @@ extension _$Decode on QS {
             growable: true,
           );
           obj[index] = leaf;
+        } else if (isValidListIndex && options.throwOnLimitExceeded) {
+          throw RangeError(_listLimitExceededMessage(options.listLimit));
+        } else if (isValidListIndex) {
+          obj[index.toString()] = leaf;
+          Utils.markOverflow(obj, index);
         } else {
           // Normalise numeric-looking keys back to their canonical string form when not a list index
           obj[index?.toString() ?? decodedRoot] = leaf;

--- a/lib/src/models/decode_options.dart
+++ b/lib/src/models/decode_options.dart
@@ -27,6 +27,7 @@ import 'package:qs_dart/src/utils.dart';
 ///   [throwOnLimitExceeded] and/or [strictDepth].
 /// - **Duplicates**: use [duplicates] to pick a strategy when the same key is
 ///   present multiple times in the input.
+/// - **Merge conflicts**: [strictMerge] controls object/scalar conflicts.
 ///
 /// See also: the options types in other ports for parity, and the individual
 /// doc comments below for precise semantics.
@@ -72,6 +73,7 @@ final class DecodeOptions with EquatableMixin {
     this.parameterLimit = 1000,
     this.parseLists = true,
     this.strictDepth = false,
+    this.strictMerge = true,
     this.strictNullHandling = false,
     this.throwOnLimitExceeded = false,
   })  : allowDots = allowDots ?? (decodeDotInKeys ?? false),
@@ -103,7 +105,7 @@ final class DecodeOptions with EquatableMixin {
   /// `a[]=` without coercing or discarding them.
   final bool allowEmptyLists;
 
-  /// Maximum list size/index that will be honored when decoding bracket lists.
+  /// Maximum list size that will be honored when decoding bracket lists.
   ///
   /// Keys like `a[9999999]` can cause excessively large sparse lists; above
   /// this limit, indices are treated as string map keys instead. The same
@@ -182,6 +184,14 @@ final class DecodeOptions with EquatableMixin {
   /// When `true`, exceeding [depth] results in a thrown error instead of a
   /// soft limit.
   final bool strictDepth;
+
+  /// When `true`, object/scalar merge conflicts are wrapped in a list.
+  ///
+  /// This matches modern Node `qs` behavior for inputs such as
+  /// `a[b]=c&a=d`, which decodes as `{'a': [{'b': 'c'}, 'd']}`.
+  /// Set to `false` to restore the legacy behavior where non-empty scalar
+  /// values are used as object keys with value `true`.
+  final bool strictMerge;
 
   /// When `true`, tokens without an `=` (e.g., `?flag`) decode to `null`
   /// rather than `""`.
@@ -280,6 +290,7 @@ final class DecodeOptions with EquatableMixin {
     final bool? parseLists,
     final bool? strictNullHandling,
     final bool? strictDepth,
+    final bool? strictMerge,
     final bool? throwOnLimitExceeded,
     final Decoder? decoder,
     final LegacyDecoder? legacyDecoder,
@@ -302,6 +313,7 @@ final class DecodeOptions with EquatableMixin {
         parseLists: parseLists ?? this.parseLists,
         strictNullHandling: strictNullHandling ?? this.strictNullHandling,
         strictDepth: strictDepth ?? this.strictDepth,
+        strictMerge: strictMerge ?? this.strictMerge,
         throwOnLimitExceeded: throwOnLimitExceeded ?? this.throwOnLimitExceeded,
         decoder: decoder ?? _decoder,
         legacyDecoder: legacyDecoder ?? _legacyDecoder,
@@ -354,6 +366,7 @@ final class DecodeOptions with EquatableMixin {
       '  parameterLimit: $parameterLimit,\n'
       '  parseLists: $parseLists,\n'
       '  strictDepth: $strictDepth,\n'
+      '  strictMerge: $strictMerge,\n'
       '  throwOnLimitExceeded: $throwOnLimitExceeded,\n'
       '  strictNullHandling: $strictNullHandling\n'
       ')';
@@ -375,6 +388,7 @@ final class DecodeOptions with EquatableMixin {
         parameterLimit,
         parseLists,
         strictDepth,
+        strictMerge,
         strictNullHandling,
         throwOnLimitExceeded,
         _decoder,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -35,7 +35,6 @@ final class Utils {
 
   /// Marks a map as an overflow container with the given max index.
   @internal
-  @visibleForTesting
   static Map<String, dynamic> markOverflow(
     final Map<String, dynamic> obj,
     final int maxIndex,
@@ -111,7 +110,7 @@ final class Utils {
         final dynamic currentTarget = frame.target;
         final dynamic currentSource = frame.source;
 
-        if (currentSource == null) {
+        if (_isFalsyMergeSource(currentSource)) {
           stack.removeLast();
           frame.onResult(currentTarget);
           continue;
@@ -248,6 +247,25 @@ final class Utils {
               frame.onResult(currentTarget);
               continue;
             }
+            if (frame.options?.strictMerge ?? true) {
+              stack.removeLast();
+              frame.onResult([currentTarget, currentSource]);
+              continue;
+            }
+            final String? key = _legacyScalarMergeKey(currentSource);
+            if (key == null || _isProtectedObjectKey(key)) {
+              stack.removeLast();
+              frame.onResult(currentTarget);
+              continue;
+            }
+            final Map<String, dynamic> mergeTarget = {
+              for (final MapEntry entry in currentTarget.entries)
+                entry.key.toString(): entry.value,
+            };
+            mergeTarget[key] = true;
+            stack.removeLast();
+            frame.onResult(mergeTarget);
+            continue;
           } else {
             if (currentTarget is! Iterable && currentSource is Iterable) {
               stack.removeLast();
@@ -260,10 +278,6 @@ final class Utils {
             frame.onResult([currentTarget, currentSource]);
             continue;
           }
-
-          stack.removeLast();
-          frame.onResult(currentTarget);
-          continue;
         }
 
         if (currentTarget == null || currentTarget is! Map) {
@@ -274,7 +288,9 @@ final class Utils {
             };
             frame.mergeTarget = mergeTarget;
             frame.mapIterator = currentSource.entries.iterator;
-            frame.overflowMax = null;
+            frame.overflowMax = isOverflow(currentSource)
+                ? _getOverflowIndex(currentSource)
+                : null;
             frame.phase = MergePhase.mapIter;
             continue;
           }
@@ -315,8 +331,12 @@ final class Utils {
         }
 
         final bool targetOverflow = isOverflow(currentTarget);
-        final int? overflowMax =
-            targetOverflow ? _getOverflowIndex(currentTarget) : null;
+        final bool sourceOverflow = isOverflow(currentSource);
+        final int? overflowMax = targetOverflow
+            ? _getOverflowIndex(currentTarget)
+            : sourceOverflow
+                ? _getOverflowIndex(currentSource)
+                : null;
 
         final Map<String, dynamic> mergeTarget =
             currentTarget is Iterable && currentSource is! Iterable
@@ -881,7 +901,7 @@ final class Utils {
       if (b is Iterable) ...b else b,
     ];
 
-    if (listLimit != null && listLimit >= 0 && result.length > listLimit) {
+    if (listLimit != null && result.length > listLimit) {
       final Map<String, dynamic> overflow = createIndexMap(result);
       return markOverflow(overflow, result.length - 1);
     }
@@ -894,6 +914,42 @@ final class Utils {
   /// Handy when a caller may pass a single value or a collection.
   static dynamic apply<T>(dynamic val, final T Function(T) fn) =>
       val is Iterable ? val.map((item) => fn(item)) : fn(val);
+
+  static bool _isFalsyMergeSource(final dynamic source) =>
+      source == null ||
+      source is Undefined ||
+      source == false ||
+      source == '' ||
+      source == 0 ||
+      source == BigInt.zero ||
+      source is double && source.isNaN;
+
+  static String? _legacyScalarMergeKey(final dynamic source) {
+    if (_isFalsyMergeSource(source)) return null;
+    return switch (source) {
+      String value => value,
+      num value => value.toString(),
+      BigInt value => value.toString(),
+      bool value => value.toString(),
+      Enum value => value.name,
+      _ => null,
+    };
+  }
+
+  static bool _isProtectedObjectKey(final String key) => const {
+        '__defineGetter__',
+        '__defineSetter__',
+        '__lookupGetter__',
+        '__lookupSetter__',
+        '__proto__',
+        'constructor',
+        'hasOwnProperty',
+        'isPrototypeOf',
+        'propertyIsEnumerable',
+        'toLocaleString',
+        'toString',
+        'valueOf',
+      }.contains(key);
 
   /// Returns `true` if `val` is a scalar we should encode as-is.
   ///

--- a/test/unit/decode_test.dart
+++ b/test/unit/decode_test.dart
@@ -1379,6 +1379,19 @@ void main() {
           'a': {'0': 'b'}
         }),
       );
+      expect(
+        QS.decode(
+          'a[]=',
+          const DecodeOptions(
+            parseLists: false,
+            listLimit: 0,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        equals({
+          'a': {'0': ''}
+        }),
+      );
     });
 
     test('allows for query string prefix', () {

--- a/test/unit/decode_test.dart
+++ b/test/unit/decode_test.dart
@@ -211,7 +211,10 @@ void main() {
       expect(
         QS.decode('a[b]=2&a=1'),
         equals({
-          'a': {'b': '2'}
+          'a': [
+            {'b': '2'},
+            '1',
+          ]
         }),
       );
     });
@@ -781,28 +784,28 @@ void main() {
 
     test('limits specific list indices to listLimit', () {
       expect(
-        QS.decode('a[20]=a', const DecodeOptions(listLimit: 20)),
+        QS.decode('a[19]=a', const DecodeOptions(listLimit: 20)),
         equals({
           'a': ['a']
         }),
       );
       expect(
-        QS.decode('a[21]=a', const DecodeOptions(listLimit: 20)),
+        QS.decode('a[20]=a', const DecodeOptions(listLimit: 20)),
         equals({
-          'a': {'21': 'a'}
+          'a': {'20': 'a'}
         }),
       );
 
       expect(
-        QS.decode('a[20]=a'),
+        QS.decode('a[19]=a'),
         equals({
           'a': ['a']
         }),
       );
       expect(
-        QS.decode('a[21]=a'),
+        QS.decode('a[20]=a'),
         equals({
-          'a': {'21': 'a'}
+          'a': {'20': 'a'}
         }),
       );
     });
@@ -1326,7 +1329,7 @@ void main() {
       expect(
         QS.decode('a[0]=b', const DecodeOptions(listLimit: 0)),
         equals({
-          'a': ['b']
+          'a': {'0': 'b'}
         }),
       );
 
@@ -2009,6 +2012,103 @@ void main() {
         );
       },
     );
+
+    test('bracket notation always combines with duplicates: first', () {
+      expect(
+        QS.decode(
+          'a=1&a=2&b[]=1&b[]=2',
+          const DecodeOptions(duplicates: Duplicates.first),
+        ),
+        equals({
+          'a': '1',
+          'b': ['1', '2'],
+        }),
+      );
+    });
+
+    test('encoded bracket notation always combines with duplicates: last', () {
+      expect(
+        QS.decode(
+          'a=1&a=2&b%5B%5D=1&b%5B%5D=2',
+          const DecodeOptions(duplicates: Duplicates.last),
+        ),
+        equals({
+          'a': '2',
+          'b': ['1', '2'],
+        }),
+      );
+    });
+  });
+
+  group('strictMerge option', () {
+    test('wraps object then scalar conflicts by default', () {
+      expect(
+        QS.decode('a[b]=c&a=d'),
+        equals({
+          'a': [
+            {'b': 'c'},
+            'd',
+          ]
+        }),
+      );
+    });
+
+    test('wraps scalar then object conflicts by default', () {
+      expect(
+        QS.decode('a=d&a[b]=c'),
+        equals({
+          'a': [
+            'd',
+            {'b': 'c'},
+          ]
+        }),
+      );
+    });
+
+    test('legacy mode adds scalar string keys', () {
+      expect(
+        QS.decode(
+          'a[b]=c&a=d',
+          const DecodeOptions(strictMerge: false),
+        ),
+        equals({
+          'a': {'b': 'c', 'd': true}
+        }),
+      );
+    });
+
+    test('legacy mode ignores empty assigned and missing-value scalars', () {
+      expect(
+        QS.decode(
+          'a[b]=c&a=',
+          const DecodeOptions(strictMerge: false),
+        ),
+        equals({
+          'a': {'b': 'c'}
+        }),
+      );
+      expect(
+        QS.decode(
+          'a[b]=c&a',
+          const DecodeOptions(strictMerge: false),
+        ),
+        equals({
+          'a': {'b': 'c'}
+        }),
+      );
+    });
+
+    test('legacy mode keeps prototype keys protected', () {
+      expect(
+        QS.decode(
+          'a[b]=c&a=toString',
+          const DecodeOptions(strictMerge: false),
+        ),
+        equals({
+          'a': {'b': 'c'}
+        }),
+      );
+    });
   });
 
   group('strictDepth option - throw cases', () {
@@ -2184,6 +2284,19 @@ void main() {
         equals({'a': '1', 'b': '2', 'c': '3', 'd': '4', 'e': '5', 'f': '6'}),
       );
     });
+
+    test('allows unlimited parameters with strict limit handling', () {
+      expect(
+        QS.decode(
+          'a=1&b=2&c=3&d=4&e=5&f=6',
+          const DecodeOptions(
+            parameterLimit: double.infinity,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        equals({'a': '1', 'b': '2', 'c': '3', 'd': '4', 'e': '5', 'f': '6'}),
+      );
+    });
   });
 
   group('list limit tests', () {
@@ -2219,14 +2332,15 @@ void main() {
       );
     });
 
-    test('strict list limit applies when duplicate scalar grows into a list',
-        () {
+    test('duplicate scalar overflow promotes to a map in strict mode', () {
       expect(
-        () => QS.decode(
+        QS.decode(
           'a=1&a=2',
           const DecodeOptions(listLimit: 1, throwOnLimitExceeded: true),
         ),
-        throwsA(isA<RangeError>()),
+        equals({
+          'a': {'0': '1', '1': '2'}
+        }),
       );
     });
 
@@ -2370,6 +2484,113 @@ void main() {
       expect(Utils.isOverflow(resultLimitOne['a']), isTrue);
     });
 
+    test('indexed listLimit boundary conditions', () {
+      expect(
+        QS.decode('a[19]=a', const DecodeOptions(listLimit: 20)),
+        equals({
+          'a': ['a']
+        }),
+      );
+      expect(
+        QS.decode('a[20]=a', const DecodeOptions(listLimit: 20)),
+        equals({
+          'a': {'20': 'a'}
+        }),
+      );
+      expect(
+        QS.decode('a[0]=b', const DecodeOptions(listLimit: 0)),
+        equals({
+          'a': {'0': 'b'}
+        }),
+      );
+      expect(
+        QS.decode('a[0]=b', const DecodeOptions(listLimit: -1)),
+        equals({
+          'a': {'0': 'b'}
+        }),
+      );
+    });
+
+    test('indexed listLimit strict overflow throws', () {
+      expect(
+        () => QS.decode(
+          'a[20]=a',
+          const DecodeOptions(
+            listLimit: 20,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        throwsA(isA<RangeError>()),
+      );
+      expect(
+        () => QS.decode(
+          'a[0]=b',
+          const DecodeOptions(
+            listLimit: 0,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        throwsA(isA<RangeError>()),
+      );
+    });
+
+    test('comma listLimit boundary conditions', () {
+      expect(
+        QS.decode(
+          'a=1,2,3',
+          const DecodeOptions(comma: true, listLimit: 5),
+        ),
+        equals({
+          'a': ['1', '2', '3']
+        }),
+      );
+      expect(
+        QS.decode(
+          'a=1,2,3',
+          const DecodeOptions(comma: true, listLimit: 3),
+        ),
+        equals({
+          'a': ['1', '2', '3']
+        }),
+      );
+
+      final result = QS.decode(
+        'a=1,2,3,4',
+        const DecodeOptions(comma: true, listLimit: 3),
+      );
+      expect(result['a'], {
+        '0': '1',
+        '1': '2',
+        '2': '3',
+        '3': '4',
+      });
+      expect(Utils.isOverflow(result['a']), isTrue);
+
+      expect(
+        () => QS.decode(
+          'a=1,2,3,4',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 3,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        throwsA(isA<RangeError>()),
+      );
+
+      expect(
+        () => QS.decode(
+          'a=1,2&a=3',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 2,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        throwsA(isA<RangeError>()),
+      );
+    });
+
     test('mixed array and object notation', () {
       expect(
         QS.decode('a[]=b&a[c]=d'),
@@ -2438,19 +2659,37 @@ void main() {
     });
 
     test('mixed [0] and [] under tight listLimit', () {
-      // Same structure as above but overflow is not tagged when order flips.
       final resultZero =
           QS.decode('a[0]=b&a[]=c', const DecodeOptions(listLimit: 0));
       expect(resultZero['a'], isA<Map<String, dynamic>>());
       expect(resultZero['a'], {
         '0': ['b', 'c']
       });
-      expect(Utils.isOverflow(resultZero['a']), isFalse);
+      expect(Utils.isOverflow(resultZero['a']), isTrue);
 
       final resultOne =
           QS.decode('a[0]=b&a[]=c', const DecodeOptions(listLimit: 1));
       expect(resultOne['a'], ['b', 'c']);
       expect(Utils.isOverflow(resultOne['a']), isFalse);
+    });
+
+    test('mixed notation produces consistent overflow results', () {
+      const expected = {
+        'a': {'0': 'b', '1': 'c', '2': 'd'}
+      };
+
+      expect(
+        QS.decode('a[]=b&a[1]=c&a=d', const DecodeOptions(listLimit: -1)),
+        equals(expected),
+      );
+      expect(
+        QS.decode('a[]=b&a[1]=c&a=d', const DecodeOptions(listLimit: 0)),
+        equals(expected),
+      );
+      expect(
+        QS.decode('a[]=b&a[1]=c&a=d', const DecodeOptions(listLimit: 1)),
+        equals(expected),
+      );
     });
   });
 
@@ -3286,14 +3525,18 @@ void main() {
   });
 
   group('Targeted coverage additions', () {
-    test('comma splitting truncates to remaining list capacity', () {
+    test('comma overflow promotes to an indexed map in non-strict mode', () {
       final result = QS.decode(
         'a=1,2,3',
         const DecodeOptions(comma: true, listLimit: 2),
       );
 
-      final Iterable<dynamic> iterable = result['a'] as Iterable;
-      expect(iterable.toList(), equals(['1', '2']));
+      expect(result['a'], {
+        '0': '1',
+        '1': '2',
+        '2': '3',
+      });
+      expect(Utils.isOverflow(result['a']), isTrue);
     });
 
     test('comma splitting throws when limit exceeded in strict mode', () {
@@ -3344,9 +3587,9 @@ void main() {
         ),
       );
 
-      final aValue = result['a'];
-      expect(aValue, isA<Iterable<dynamic>>());
-      expect((aValue as Iterable<dynamic>).length, 5);
+      final aValue = result['a'] as Map<String, dynamic>;
+      expect(aValue.length, 26);
+      expect(Utils.isOverflow(aValue), isTrue);
     });
 
     test('strict depth throws when additional bracket groups remain', () {

--- a/test/unit/models/decode_options_test.dart
+++ b/test/unit/models/decode_options_test.dart
@@ -51,6 +51,7 @@ void main() {
         interpretNumericEntities: true,
         parameterLimit: 200,
         parseLists: true,
+        strictMerge: false,
         strictNullHandling: true,
       );
 
@@ -69,6 +70,7 @@ void main() {
       expect(newOptions.interpretNumericEntities, isTrue);
       expect(newOptions.parameterLimit, 200);
       expect(newOptions.parseLists, isTrue);
+      expect(newOptions.strictMerge, isFalse);
       expect(newOptions.strictNullHandling, isTrue);
       expect(newOptions, equals(options));
     });
@@ -88,6 +90,7 @@ void main() {
         interpretNumericEntities: true,
         parameterLimit: 100,
         parseLists: false,
+        strictMerge: false,
         strictNullHandling: true,
       );
 
@@ -105,6 +108,7 @@ void main() {
         interpretNumericEntities: false,
         parameterLimit: 200,
         parseLists: true,
+        strictMerge: true,
         strictNullHandling: false,
       );
 
@@ -121,6 +125,7 @@ void main() {
       expect(newOptions.interpretNumericEntities, isFalse);
       expect(newOptions.parameterLimit, 200);
       expect(newOptions.parseLists, isTrue);
+      expect(newOptions.strictMerge, isTrue);
       expect(newOptions.strictNullHandling, isFalse);
     });
 
@@ -155,6 +160,7 @@ void main() {
         parameterLimit: 100,
         parseLists: false,
         strictDepth: false,
+        strictMerge: false,
         strictNullHandling: true,
       );
 
@@ -177,6 +183,7 @@ void main() {
           '  parameterLimit: 100,\n'
           '  parseLists: false,\n'
           '  strictDepth: false,\n'
+          '  strictMerge: false,\n'
           '  throwOnLimitExceeded: false,\n'
           '  strictNullHandling: true\n'
           ')',

--- a/test/unit/uri_extension_test.dart
+++ b/test/unit/uri_extension_test.dart
@@ -538,7 +538,7 @@ void main() {
         Uri.parse('$testUrl?a[20]=a')
             .queryParametersQs(const DecodeOptions(listLimit: 20)),
         equals({
-          'a': ['a']
+          'a': {'20': 'a'}
         }),
       );
       expect(
@@ -552,7 +552,7 @@ void main() {
       expect(
         Uri.parse('$testUrl?a[20]=a').queryParametersQs(),
         equals({
-          'a': ['a']
+          'a': {'20': 'a'}
         }),
       );
       expect(
@@ -1011,7 +1011,7 @@ void main() {
         Uri.parse('$testUrl?a[0]=b')
             .queryParametersQs(const DecodeOptions(listLimit: 0)),
         equals({
-          'a': ['b']
+          'a': {'0': 'b'}
         }),
       );
 

--- a/test/unit/utils_test.dart
+++ b/test/unit/utils_test.dart
@@ -1336,6 +1336,25 @@ void main() {
         expect(target, {'a': 1});
       });
 
+      test('legacy strictMerge=false stringifies non-string scalar keys', () {
+        final cases = <(dynamic, String)>[
+          (42, '42'),
+          (BigInt.from(42), '42'),
+          (true, 'true'),
+          (DummyEnum.lorem, 'lorem'),
+        ];
+
+        for (final (source, key) in cases) {
+          final result = Utils.merge(
+            <String, dynamic>{'a': 1},
+            source,
+            const DecodeOptions(strictMerge: false),
+          );
+
+          expect(result, {'a': 1, key: true});
+        }
+      });
+
       test('legacy strictMerge=false ignores protected scalar keys', () {
         final target = <String, dynamic>{'a': 1};
         final result = Utils.merge(

--- a/test/unit/utils_test.dart
+++ b/test/unit/utils_test.dart
@@ -1388,6 +1388,19 @@ void main() {
         expect(map['1'], equals('x'));
       });
 
+      test('preserves source overflow marker when merging into map target', () {
+        final overflow = Utils.markOverflow(<String, dynamic>{'1': 'b'}, 1);
+        final result = Utils.merge(<String, dynamic>{'0': 'a'}, overflow);
+
+        expect(result, isA<Map<String, dynamic>>());
+        final map = result as Map<String, dynamic>;
+        expect(map, {'0': 'a', '1': 'b'});
+        expect(Utils.isOverflow(map), isTrue);
+
+        final appended = Utils.merge(map, 'c') as Map<String, dynamic>;
+        expect(appended, {'0': 'a', '1': 'b', '2': 'c'});
+      });
+
       test('wraps scalar targets into list with map element when merging maps',
           () {
         final result = Utils.merge('seed', {'a': 'b'});

--- a/test/unit/utils_test.dart
+++ b/test/unit/utils_test.dart
@@ -998,7 +998,7 @@ void main() {
             '0': ['x', 'a'],
             '1': 'b',
           });
-          expect(Utils.isOverflow(merged), isFalse);
+          expect(Utils.isOverflow(merged), isTrue);
         });
       });
     });
@@ -1314,12 +1314,37 @@ void main() {
     });
 
     group('Utils.merge edge branches', () {
-      test('returns non-overflow map target unchanged for scalar source', () {
+      test('wraps non-overflow map target with scalar source by default', () {
         final target = <String, dynamic>{'a': 1};
         final result = Utils.merge(target, 'x');
 
-        expect(result, same(target));
-        expect(result, equals({'a': 1}));
+        expect(result, [
+          {'a': 1},
+          'x',
+        ]);
+      });
+
+      test('legacy strictMerge=false adds scalar source as a key', () {
+        final target = <String, dynamic>{'a': 1};
+        final result = Utils.merge(
+          target,
+          'x',
+          const DecodeOptions(strictMerge: false),
+        );
+
+        expect(result, {'a': 1, 'x': true});
+        expect(target, {'a': 1});
+      });
+
+      test('legacy strictMerge=false ignores protected scalar keys', () {
+        final target = <String, dynamic>{'a': 1};
+        final result = Utils.merge(
+          target,
+          'toString',
+          const DecodeOptions(strictMerge: false),
+        );
+
+        expect(result, {'a': 1});
       });
 
       test('normalizes to map when Undefined persists and parseLists is false',


### PR DESCRIPTION
This pull request introduces significant improvements to the query string decoding logic to better match the behavior of Node's `qs` library, particularly regarding list limits, bracket notation, duplicate handling, and object/scalar merge conflicts. The main change is the addition of the `DecodeOptions.strictMerge` option, which defaults to modern `qs` behavior for merging objects and scalars. The PR also fixes several edge cases to ensure parity with recent versions of `qs`, and updates the documentation accordingly.

**Decode behavior improvements:**

* Added `DecodeOptions.strictMerge` (default: true) to control how object/scalar merge conflicts are handled, matching modern Node `qs` behavior by wrapping conflicts in a list, with an option to restore legacy merging. [[1]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081R76) [[2]](diffhunk://#diff-4aeecc3fbbab5fc1055a922f4a72e6375895de001b03227cb05352228d3ba081R188-R195) Fb87a85fL247R247, [[3]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dR918-R953)
* Updated handling of bracket notation so that duplicate bracketed keys are always combined into arrays, regardless of the selected duplicate strategy, matching Node `qs` 6.15.0.
* Improved list limit handling for indexed notation and comma-separated lists to match Node `qs` 6.14.2, including correct overflow and unlimited parsing behavior. [[1]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL52-R50) [[2]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fR70-R84) [[3]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL437-R449) [[4]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fR458-R462) [[5]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL884-R904)
* Fixed merge logic to properly handle legacy scalar-key merge mode when `strictMerge` is false, including protection against unsafe object keys. (Fb87a85fL247R247, [lib/src/utils.dartR918-R953](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dR918-R953))

**Documentation updates:**

* Updated `README.md` and `CHANGELOG.md` to document the new `strictMerge` option, improved duplicate handling, and clarified list limit semantics. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R329-R343) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L471-R497) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R523-R551)

**Other codebase improvements:**

* Refactored and clarified internal utility methods for merging and overflow handling, and improved comments for maintainability. [[1]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL38) [[2]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL277-R293) [[3]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL318-R339)

These changes ensure that the Dart implementation closely tracks the behavior of Node's `qs` library, improving compatibility and predictability for users porting code or expecting parity.