### PR TITLE
:white_check_mark: enhance comparison testing by improving output handling and adding dart2js support

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,7 +36,7 @@ Purpose: Provide just enough project context so an AI assistant can make correct
 ### 4. Testing Strategy
 * Unit tests in `test/unit/` mirror README examples & edge cases (list formats, depth, duplicates, charsets, null handling, custom hooks).
 * E2E tests in `test/e2e/` exercise higher‑level URI extensions.
-* Comparison tests (`test/comparison/`) ensure parity with the JS implementation via fixture JSON & a Node script; run `test/comparison/compare_outputs.sh` after semantic changes to core encode/decode logic.
+* Comparison tests (`test/comparison/`) ensure Dart VM and dart2js parity with the JS implementation via fixture JSON & a Node script; run `test/comparison/compare_outputs.sh` after semantic changes to core encode/decode logic.
 * When adding behavior, first add/modify a unit test replicating the JS `qs` behavior (consult upstream if uncertain), then adjust implementation.
 
 ### 5. Dev Workflow / Commands

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,16 +237,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run a comparison test between qs_dart and qs for JavaScript
         working-directory: test/comparison
-        run: |
-          set -e
-          node_output=$(node qs.js)
-          dart_output=$(dart run qs.dart)
-          if [ "$node_output" == "$dart_output" ]; then
-              echo "The outputs are identical."
-          else
-              echo "The outputs are different."
-              exit 1
-          fi
+        run: bash compare_outputs.sh
   ci_required:
     name: "CI Required"
     if: ${{ always() }}

--- a/test/comparison/compare_outputs.sh
+++ b/test/comparison/compare_outputs.sh
@@ -1,17 +1,33 @@
 #!/usr/bin/env bash
 
-# Get the directory of the script
-script_dir=$(dirname "$0")
+set -euo pipefail
 
-# Run the JavaScript and Dart scripts and save their outputs
-node_output=$(node "$script_dir/qs.js")
-dart_output=$(dart run "$script_dir/qs.dart")
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT
 
-# Compare the outputs
-if [ "$node_output" == "$dart_output" ]; then
-    echo "The outputs are identical."
-    exit 0
-else
-    echo "The outputs are different."
+compare_outputs() {
+  local expected="$1"
+  local actual="$2"
+  local description="$3"
+
+  if ! diff -u "$expected" "$actual"; then
+    echo "$description outputs are different." >&2
     exit 1
-fi
+  fi
+}
+
+node "$script_dir/qs.js" > "$tmp_dir/node.out"
+dart run "$script_dir/qs.dart" > "$tmp_dir/dart_vm.out"
+
+test_cases_base64=$(base64 < "$script_dir/test_cases.json" | tr -d '\r\n')
+dart compile js -O2 \
+  -DQS_COMPARISON_TEST_CASES_BASE64="$test_cases_base64" \
+  "$script_dir/qs_dart2js.dart" \
+  -o "$tmp_dir/qs_dart2js.js"
+node "$tmp_dir/qs_dart2js.js" > "$tmp_dir/dart2js.out"
+
+compare_outputs "$tmp_dir/node.out" "$tmp_dir/dart_vm.out" "Node and Dart VM"
+compare_outputs "$tmp_dir/node.out" "$tmp_dir/dart2js.out" "Node and dart2js"
+
+echo "The Node, Dart VM, and dart2js outputs are identical."

--- a/test/comparison/comparison.dart
+++ b/test/comparison/comparison.dart
@@ -1,0 +1,15 @@
+import 'dart:convert' show jsonDecode, jsonEncode;
+
+import 'package:qs_dart/qs_dart.dart' as qs;
+
+Iterable<String> buildComparisonLines(String testCasesJson) sync* {
+  final List<Map<String, dynamic>> e2eTestCases =
+      List.from(jsonDecode(testCasesJson));
+
+  for (final Map<String, dynamic> testCase in e2eTestCases) {
+    final String encoded = qs.encode(testCase['data']);
+    final Map decoded = qs.decode(testCase['encoded']);
+    yield 'Encoded: $encoded';
+    yield 'Decoded: ${jsonEncode(decoded)}';
+  }
+}

--- a/test/comparison/package.json
+++ b/test/comparison/package.json
@@ -4,7 +4,7 @@
   "description": "A comparison of query string parsing libraries",
   "author": "Klemen Tusar",
   "license": "BSD-3-Clause",
-  "packageManager": "pnpm@11.1.3",
+  "packageManager": "pnpm@11.5.2",
   "dependencies": {
     "qs": "^6.15.2"
   }

--- a/test/comparison/qs.dart
+++ b/test/comparison/qs.dart
@@ -1,9 +1,9 @@
-import 'dart:convert' show jsonDecode, jsonEncode;
 import 'dart:io' show File, Platform, exitCode, stdout;
 
 import 'package:cli_script/cli_script.dart' show wrapMain;
 import 'package:path/path.dart' as p;
-import 'package:qs_dart/qs_dart.dart' as qs;
+
+import 'comparison.dart';
 
 void main() {
   wrapMain(() {
@@ -12,16 +12,9 @@ void main() {
     final String scriptDir = p.dirname(Platform.script.toFilePath());
     final File file = File(p.join(scriptDir, 'test_cases.json'));
     final String contents = file.readAsStringSync();
-    final List<Map<String, dynamic>> e2eTestCases =
-        List<Map<String, dynamic>>.from(
-      jsonDecode(contents),
-    );
 
-    for (final testCase in e2eTestCases) {
-      final String encoded = qs.encode(testCase['data']);
-      final Map decoded = qs.decode(testCase['encoded']);
-      stdout.writeln('Encoded: $encoded');
-      stdout.writeln('Decoded: ${jsonEncode(decoded)}');
+    for (final String line in buildComparisonLines(contents)) {
+      stdout.writeln(line);
     }
   });
 }

--- a/test/comparison/qs_dart2js.dart
+++ b/test/comparison/qs_dart2js.dart
@@ -1,0 +1,17 @@
+import 'dart:convert' show base64Decode, utf8;
+
+import 'comparison.dart';
+
+void main() {
+  const String encodedTestCases =
+      String.fromEnvironment('QS_COMPARISON_TEST_CASES_BASE64');
+  if (encodedTestCases.isEmpty) {
+    throw StateError('Missing QS_COMPARISON_TEST_CASES_BASE64.');
+  }
+
+  final String testCasesJson = utf8.decode(base64Decode(encodedTestCases));
+  for (final String line in buildComparisonLines(testCasesJson)) {
+    // ignore: avoid_print
+    print(line);
+  }
+}


### PR DESCRIPTION
This pull request improves the robustness and coverage of the cross-language comparison tests between the Dart and JavaScript implementations, ensuring output parity for both Dart VM and dart2js compiled code. It refactors the comparison script, introduces new Dart test harness files, and updates documentation and workflow to reflect these enhancements.

**Comparison test improvements:**

* Refactored `compare_outputs.sh` to compare outputs from Node.js, Dart VM, and dart2js, ensuring all three environments produce identical results and providing clearer error messages. Temporary files are handled safely, and the script exits on any mismatch.
* Added `qs_dart2js.dart` to enable running the comparison tests against Dart compiled to JavaScript (dart2js), using a base64-encoded environment variable for test cases.
* Extracted comparison logic into `comparison.dart` and refactored `qs.dart` to use this shared code, reducing duplication and simplifying test case handling. [[1]](diffhunk://#diff-d799fa4ed7123537081b3021c4b1ab0913a2695412837e66fda83b055d74cc0aR1-R15) [[2]](diffhunk://#diff-d88f8bb6cf03201d319bafa5ac55c9458f1de26b9d0c595972a59cf2a34becf4L1-R6) [[3]](diffhunk://#diff-d88f8bb6cf03201d319bafa5ac55c9458f1de26b9d0c595972a59cf2a34becf4L15-R17)

**Workflow and documentation updates:**

* Updated the GitHub Actions workflow to call the new `compare_outputs.sh` script instead of duplicating comparison logic inline.
* Clarified in `.github/copilot-instructions.md` that comparison tests now check both Dart VM and dart2js against the JavaScript implementation.

**Dependency update:**

* Updated `pnpm` version in `package.json` for the comparison test suite.