### PR TITLE
:recycle: remove export of internal `Undefined` sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.0-dev
+
+* [BREAKING] stop exporting the internal `Undefined` sentinel from the public API
+
 ## 1.7.6
 
 * [CHORE] improve decode internals readability with clearer helper extraction, comments, formatting, and local type annotations

--- a/README.md
+++ b/README.md
@@ -923,20 +923,6 @@ expect(
 );
 ```
 
-Properties set to [Undefined] are omitted entirely:
-
-```dart
-expect(
-  QS.encode(
-    {
-      'a': null,
-      'b': const Undefined(),
-    },
-  ),
-  equals('a='),
-);
-```
-
 The query string may optionally be prepended with a question mark:
 
 ```dart
@@ -1032,7 +1018,6 @@ expect(
     EncodeOptions(
       encode: false,
       filter: (prefix, value) => switch (prefix) {
-        'b' => const Undefined(),
         'e[f]' => (value as DateTime).millisecondsSinceEpoch,
         'e[g][0]' => (value as num) * 2,
         _ => value,

--- a/example/example.dart
+++ b/example/example.dart
@@ -477,9 +477,6 @@ void main() {
       equals(''),
     );
 
-    /// Properties that are `Undefined` will be omitted entirely:
-    expect(QS.encode({'a': null, 'b': const Undefined()}), equals('a='));
-
     /// The query string may optionally be prepended with a question mark:
     expect(
       QS.encode({
@@ -541,7 +538,6 @@ void main() {
         EncodeOptions(
           encode: false,
           filter: (prefix, value) => switch (prefix) {
-            'b' => const Undefined(),
             'e[f]' => (value as DateTime).millisecondsSinceEpoch,
             'e[g][0]' => (value as num) * 2,
             _ => value,

--- a/lib/qs_dart.dart
+++ b/lib/qs_dart.dart
@@ -27,6 +27,5 @@ export 'src/enums/sentinel.dart';
 export 'src/methods.dart' show decode, encode;
 export 'src/models/decode_options.dart';
 export 'src/models/encode_options.dart';
-export 'src/models/undefined.dart';
 export 'src/qs.dart';
 export 'src/uri.dart';

--- a/test/unit/encode_test.dart
+++ b/test/unit/encode_test.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data' show ByteBuffer, Uint8List;
 
 import 'package:euc/jis.dart';
 import 'package:qs_dart/qs_dart.dart';
+import 'package:qs_dart/src/models/undefined.dart';
 import 'package:qs_dart/src/utils.dart';
 import 'package:test/test.dart';
 

--- a/test/unit/example.dart
+++ b/test/unit/example.dart
@@ -629,17 +629,6 @@ void main() {
         ),
         equals(''));
 
-    /// Properties that are `Undefined` will be omitted entirely:
-    expect(
-      QS.encode(
-        {
-          'a': null,
-          'b': const Undefined(),
-        },
-      ),
-      equals('a='),
-    );
-
     /// The query string may optionally be prepended with a question mark:
     expect(
       QS.encode(
@@ -721,7 +710,6 @@ void main() {
         EncodeOptions(
           encode: false,
           filter: (prefix, value) => switch (prefix) {
-            'b' => const Undefined(),
             'e[f]' => (value as DateTime).millisecondsSinceEpoch,
             'e[g][0]' => (value as num) * 2,
             _ => value,

--- a/test/unit/extensions/extensions_test.dart
+++ b/test/unit/extensions/extensions_test.dart
@@ -1,5 +1,5 @@
-import 'package:qs_dart/qs_dart.dart';
 import 'package:qs_dart/src/extensions/extensions.dart';
+import 'package:qs_dart/src/models/undefined.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/unit/utils_test.dart
+++ b/test/unit/utils_test.dart
@@ -4,6 +4,7 @@ import 'dart:convert' show latin1, utf8;
 import 'dart:typed_data' show Uint8List;
 
 import 'package:qs_dart/qs_dart.dart';
+import 'package:qs_dart/src/models/undefined.dart';
 import 'package:qs_dart/src/utils.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
This pull request introduces a breaking change by removing the internal `Undefined` sentinel from the public API, and updates documentation, examples, and tests to reflect this change. The main impact is that users can no longer import or rely on `Undefined` from the public package interface.

**Breaking API change:**

* The internal `Undefined` sentinel is no longer exported from the public API (`qs_dart.dart`). Users who need it must now import it directly from `src/models/undefined.dart`. [[1]](diffhunk://#diff-13f1a17cf7bfe6a6478e783d2bce85ab0cb6bc065d22c017d022a0e88db36c78L30) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1-R4)

**Documentation and example updates:**

* Removed all usage and documentation of `Undefined` from `README.md`, `example/example.dart`, and `test/unit/example.dart` to align with the new API. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L926-L939) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1035) [[3]](diffhunk://#diff-e30b82ca6132dc2e1109da46c81bf0a3e648a4efc0d9ba8c23e1e16624551127L480-L482) [[4]](diffhunk://#diff-e30b82ca6132dc2e1109da46c81bf0a3e648a4efc0d9ba8c23e1e16624551127L544) [[5]](diffhunk://#diff-e58dab6cbcd018eb6a4da8e537ea92919b4f4c950463fee8037c08eb188e2572L632-L642) [[6]](diffhunk://#diff-e58dab6cbcd018eb6a4da8e537ea92919b4f4c950463fee8037c08eb188e2572L724)

**Test and import adjustments:**

* Updated test files to import `Undefined` from its internal location, ensuring tests continue to work for internal use. [[1]](diffhunk://#diff-41dacfda7ab1a594c9434c2dbdf63192c8b55af110c6c24116aa9b09e5524a55R8) [[2]](diffhunk://#diff-f3d1a1e2be3bb8e7c4700f7adb558d98adc5d35ad5539916a7e82c383c892e2dL1-R2) [[3]](diffhunk://#diff-33fce9b347a2eae4cfab2e537107957b4baea6b40183e01ce267391db4a25219R7)