### PR TITLE
:sparkles: qs.js 6.15.3 parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.1-dev
+
+* [FIX] match Node `qs` 6.15.3 cumulative list-limit enforcement across duplicate-key combinations and mixed list merges
+* [FIX] reject oversized flat comma values before allocating their split lists when `throwOnLimitExceeded` is enabled
+* [CHORE] add Node `qs` 6.15.3 regression coverage for unbalanced bracket keys, chunk-boundary surrogate pairs, and cyclic compaction
+
 ## 1.8.0
 
 * [BREAKING] stop exporting the internal `Undefined` sentinel from the public API

--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -56,7 +56,7 @@ extension _$Decode on QS {
         while (commaIndex >= 0) {
           commaCount++;
           if (commaCount >= options.listLimit) {
-            throw RangeError(_listLimitExceededMessage(options.listLimit));
+            Utils.throwListLimitExceeded(options.listLimit);
           }
           commaIndex = val.indexOf(',', commaIndex + 1);
         }
@@ -68,18 +68,11 @@ extension _$Decode on QS {
     if (options.throwOnLimitExceeded &&
         isListGrowthPath &&
         currentListLength >= options.listLimit) {
-      throw RangeError(_listLimitExceededMessage(options.listLimit));
+      Utils.throwListLimitExceeded(options.listLimit);
     }
 
     return val;
   }
-
-  /// Helper to generate consistent error messages for list limit violations,
-  /// based on the configured `listLimit`.
-  static String _listLimitExceededMessage(final int listLimit) => listLimit < 0
-      ? 'List parsing is disabled (listLimit < 0).'
-      : 'List limit exceeded. Only $listLimit '
-          'element${listLimit == 1 ? '' : 's'} allowed in a list.';
 
   /// Applies comma-list limit handling after values have been decoded and
   /// after `[]` suffix wrapping, matching Node `qs` ordering.
@@ -91,7 +84,7 @@ extension _$Decode on QS {
       return val;
     }
     if (options.throwOnLimitExceeded) {
-      throw RangeError(_listLimitExceededMessage(options.listLimit));
+      Utils.throwListLimitExceeded(options.listLimit);
     }
     return Utils.combine(
       [],
@@ -348,17 +341,8 @@ extension _$Decode on QS {
       final bool existing = obj.containsKey(key);
       switch ((existing, options.duplicates)) {
         case (true, Duplicates.combine):
-          // Existing key + `combine` policy: merge old/new values.
-          obj[key] = Utils.combine(
-            obj[key],
-            val,
-            listLimit: options.listLimit,
-            throwOnLimitExceeded: options.throwOnLimitExceeded,
-          );
-          break;
         case (true, _) when bracketSuffix:
-          // `qs` always combines duplicate bracket-notation keys, even when
-          // the duplicates option is `first` or `last`.
+          // Combine by policy, and always combine bracket-notation duplicates.
           obj[key] = Utils.combine(
             obj[key],
             val,
@@ -501,7 +485,7 @@ extension _$Decode on QS {
           );
           obj[index] = leaf;
         } else if (isValidListIndex && options.throwOnLimitExceeded) {
-          throw RangeError(_listLimitExceededMessage(options.listLimit));
+          Utils.throwListLimitExceeded(options.listLimit);
         } else if (isValidListIndex) {
           obj[index.toString()] = leaf;
           Utils.markOverflow(obj, index);

--- a/lib/src/extensions/decode.dart
+++ b/lib/src/extensions/decode.dart
@@ -34,6 +34,8 @@ extension _$Decode on QS {
   ///
   /// The `currentListLength` is used to guard incremental growth when we are
   /// already building a list for a given key path.
+  /// `isFlatListValue` distinguishes flat comma lists (`a=1,2`, `a[b]=1,2`)
+  /// from nested `[]=` comma groups, which count as one outer list element.
   ///
   /// **Negative `listLimit` semantics:** a negative value disables numeric-index parsing
   /// elsewhere (e.g. `[2]` segments become string keys). For comma‑splits specifically:
@@ -44,9 +46,21 @@ extension _$Decode on QS {
     final DecodeOptions options,
     final int currentListLength,
     final bool isListGrowthPath,
+    final bool isFlatListValue,
   ) {
     // Fast-path: split comma-separated scalars into a list when requested.
     if (val is String && val.isNotEmpty && options.comma && val.contains(',')) {
+      if (isFlatListValue && options.throwOnLimitExceeded) {
+        int commaCount = 0;
+        int commaIndex = val.indexOf(',');
+        while (commaIndex >= 0) {
+          commaCount++;
+          if (commaCount >= options.listLimit) {
+            throw RangeError(_listLimitExceededMessage(options.listLimit));
+          }
+          commaIndex = val.indexOf(',', commaIndex + 1);
+        }
+      }
       return _splitCommaValue(val);
     }
 
@@ -79,7 +93,12 @@ extension _$Decode on QS {
     if (options.throwOnLimitExceeded) {
       throw RangeError(_listLimitExceededMessage(options.listLimit));
     }
-    return Utils.combine([], val, listLimit: options.listLimit);
+    return Utils.combine(
+      [],
+      val,
+      listLimit: options.listLimit,
+      throwOnLimitExceeded: options.throwOnLimitExceeded,
+    );
   }
 
   /// Splits a comma-separated value into parts, respecting an optional `maxParts` limit.
@@ -295,6 +314,7 @@ extension _$Decode on QS {
             options,
             currentListLength,
             listGrowthFromKey,
+            !bracketSuffix,
           ),
           (final dynamic v) =>
               options.decodeValue(v as String?, charset: charset),
@@ -329,12 +349,22 @@ extension _$Decode on QS {
       switch ((existing, options.duplicates)) {
         case (true, Duplicates.combine):
           // Existing key + `combine` policy: merge old/new values.
-          obj[key] = Utils.combine(obj[key], val, listLimit: options.listLimit);
+          obj[key] = Utils.combine(
+            obj[key],
+            val,
+            listLimit: options.listLimit,
+            throwOnLimitExceeded: options.throwOnLimitExceeded,
+          );
           break;
         case (true, _) when bracketSuffix:
           // `qs` always combines duplicate bracket-notation keys, even when
           // the duplicates option is `first` or `last`.
-          obj[key] = Utils.combine(obj[key], val, listLimit: options.listLimit);
+          obj[key] = Utils.combine(
+            obj[key],
+            val,
+            listLimit: options.listLimit,
+            throwOnLimitExceeded: options.throwOnLimitExceeded,
+          );
           break;
         case (false, _):
         case (true, Duplicates.last):
@@ -411,6 +441,7 @@ extension _$Decode on QS {
             options,
             currentListLength,
             isListGrowthPath,
+            false,
           );
 
     for (int i = chain.length - 1; i >= 0; --i) {
@@ -428,7 +459,12 @@ extension _$Decode on QS {
           obj = options.allowEmptyLists &&
                   (leaf == '' || (options.strictNullHandling && leaf == null))
               ? List<dynamic>.empty(growable: true)
-              : Utils.combine([], leaf, listLimit: options.listLimit);
+              : Utils.combine(
+                  [],
+                  leaf,
+                  listLimit: options.listLimit,
+                  throwOnLimitExceeded: options.throwOnLimitExceeded,
+                );
         }
       } else {
         obj = <String, dynamic>{};

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -65,7 +65,8 @@ final class Utils {
     return parsed > current ? parsed : current;
   }
 
-  static Never _throwListLimitExceeded(final int listLimit) {
+  @internal
+  static Never throwListLimitExceeded(final int listLimit) {
     throw RangeError(
       listLimit < 0
           ? 'List parsing is disabled (listLimit < 0).'
@@ -82,7 +83,7 @@ final class Utils {
       return result;
     }
     if (options.throwOnLimitExceeded) {
-      _throwListLimitExceeded(options.listLimit);
+      throwListLimitExceeded(options.listLimit);
     }
     return markOverflow(createIndexMap(result), result.length - 1);
   }
@@ -916,7 +917,7 @@ final class Utils {
   }) {
     if (isOverflow(a)) {
       if (throwOnLimitExceeded && listLimit != null) {
-        _throwListLimitExceeded(listLimit);
+        throwListLimitExceeded(listLimit);
       }
       int newIndex = _getOverflowIndex(a);
       if (b is Iterable) {
@@ -939,7 +940,7 @@ final class Utils {
 
     if (listLimit != null && result.length > listLimit) {
       if (throwOnLimitExceeded) {
-        _throwListLimitExceeded(listLimit);
+        throwListLimitExceeded(listLimit);
       }
       final Map<String, dynamic> overflow = createIndexMap(result);
       return markOverflow(overflow, result.length - 1);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -65,6 +65,28 @@ final class Utils {
     return parsed > current ? parsed : current;
   }
 
+  static Never _throwListLimitExceeded(final int listLimit) {
+    throw RangeError(
+      listLimit < 0
+          ? 'List parsing is disabled (listLimit < 0).'
+          : 'List limit exceeded. Only $listLimit '
+              'element${listLimit == 1 ? '' : 's'} allowed in a list.',
+    );
+  }
+
+  static dynamic _enforceListLimit(
+    final List<dynamic> result,
+    final DecodeOptions? options,
+  ) {
+    if (options == null || result.length <= options.listLimit) {
+      return result;
+    }
+    if (options.throwOnLimitExceeded) {
+      _throwListLimitExceeded(options.listLimit);
+    }
+    return markOverflow(createIndexMap(result), result.length - 1);
+  }
+
   /// Deeply merges `source` into `target` while preserving insertion order
   /// and list semantics used by `qs`.
   ///
@@ -182,11 +204,12 @@ final class Utils {
               }
 
               stack.removeLast();
-              frame.onResult(
-                currentTarget is Set
-                    ? indexedTarget.values.toSet()
-                    : indexedTarget.values.toList(),
-              );
+              frame.onResult(currentTarget is Set
+                  ? indexedTarget.values.toSet()
+                  : _enforceListLimit(
+                      indexedTarget.values.toList(),
+                      frame.options,
+                    ));
               continue;
             }
 
@@ -203,13 +226,14 @@ final class Utils {
               }
 
               stack.removeLast();
-              frame.onResult(
-                currentTarget is Set
-                    ? (Set.of(currentTarget)
-                      ..addAll(currentSource.whereNotType<Undefined>()))
-                    : (List.of(currentTarget)
-                      ..addAll(currentSource.whereNotType<Undefined>())),
-              );
+              frame.onResult(currentTarget is Set
+                  ? (Set.of(currentTarget)
+                    ..addAll(currentSource.whereNotType<Undefined>()))
+                  : _enforceListLimit(
+                      List.of(currentTarget)
+                        ..addAll(currentSource.whereNotType<Undefined>()),
+                      frame.options,
+                    ));
               continue;
             }
 
@@ -217,7 +241,7 @@ final class Utils {
               final List<dynamic> merged = List<dynamic>.of(currentTarget)
                 ..add(currentSource);
               stack.removeLast();
-              frame.onResult(merged);
+              frame.onResult(_enforceListLimit(merged, frame.options));
               continue;
             }
             if (currentTarget is Set) {
@@ -269,10 +293,12 @@ final class Utils {
             continue;
           } else {
             if (currentTarget is! Iterable && currentSource is Iterable) {
+              final List<dynamic> merged = [
+                currentTarget,
+                ...currentSource.whereNotType<Undefined>(),
+              ];
               stack.removeLast();
-              frame.onResult(
-                [currentTarget, ...currentSource.whereNotType<Undefined>()],
-              );
+              frame.onResult(_enforceListLimit(merged, frame.options));
               continue;
             }
             stack.removeLast();
@@ -316,18 +342,17 @@ final class Utils {
           }
 
           stack.removeLast();
-          frame.onResult(
-            [
-              if (currentTarget is Iterable)
-                ...currentTarget.whereNotType<Undefined>()
-              else if (currentTarget != null)
-                currentTarget,
-              if (currentSource is Iterable)
-                ...(currentSource as Iterable).whereNotType<Undefined>()
-              else
-                currentSource,
-            ],
-          );
+          final List<dynamic> combined = [
+            if (currentTarget is Iterable)
+              ...currentTarget.whereNotType<Undefined>()
+            else if (currentTarget != null)
+              currentTarget,
+            if (currentSource is Iterable)
+              ...(currentSource as Iterable).whereNotType<Undefined>()
+            else
+              currentSource,
+          ];
+          frame.onResult(_enforceListLimit(combined, frame.options));
           continue;
         }
 
@@ -413,7 +438,10 @@ final class Utils {
         }
         final resultList = frame.targetIsSet
             ? frame.indexedTarget!.values.toSet()
-            : frame.indexedTarget!.values.toList();
+            : _enforceListLimit(
+                frame.indexedTarget!.values.toList(),
+                frame.options,
+              );
         stack.removeLast();
         frame.onResult(resultList);
         continue;
@@ -868,10 +896,12 @@ final class Utils {
   /// Concatenates two values, spreading iterables.
   ///
   /// When [listLimit] is provided and exceeded, returns a map with string keys.
-  /// Any throwing behavior is enforced earlier during parsing, matching Node `qs`.
+  /// When [throwOnLimitExceeded] is true, throws instead of returning an
+  /// overflow map.
   ///
   /// **Note:** If [a] is already an overflow object, this method mutates [a]
-  /// in place by appending entries from [b].
+  /// in place by appending entries from [b], unless strict limit enforcement
+  /// throws first.
   ///
   /// Examples:
   /// ```dart
@@ -882,8 +912,12 @@ final class Utils {
     final dynamic a,
     final dynamic b, {
     final int? listLimit,
+    final bool throwOnLimitExceeded = false,
   }) {
     if (isOverflow(a)) {
+      if (throwOnLimitExceeded && listLimit != null) {
+        _throwListLimitExceeded(listLimit);
+      }
       int newIndex = _getOverflowIndex(a);
       if (b is Iterable) {
         for (final dynamic item in b) {
@@ -904,6 +938,9 @@ final class Utils {
     ];
 
     if (listLimit != null && result.length > listLimit) {
+      if (throwOnLimitExceeded) {
+        _throwListLimitExceeded(listLimit);
+      }
       final Map<String, dynamic> overflow = createIndexMap(result);
       return markOverflow(overflow, result.length - 1);
     }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -973,7 +973,7 @@ final class Utils {
     };
   }
 
-  static bool _isProtectedObjectKey(final String key) => const {
+  static bool _isProtectedObjectKey(final String key) => const <String>{
         '__defineGetter__',
         '__defineSetter__',
         '__lookupGetter__',

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -52,9 +52,8 @@ final class Utils {
   static int _getOverflowIndex(final Map obj) => _overflowIndex[obj] ?? -1;
 
   /// Updates the tracked max numeric index for an overflow map.
-  static void _setOverflowIndex(final Map obj, final int maxIndex) {
-    _overflowIndex[obj] = maxIndex;
-  }
+  static void _setOverflowIndex(final Map obj, final int maxIndex) =>
+      _overflowIndex[obj] = maxIndex;
 
   /// Returns the larger of the current max and the parsed numeric key (if any).
   static int _updateOverflowMax(final int current, final String key) {
@@ -66,14 +65,12 @@ final class Utils {
   }
 
   @internal
-  static Never throwListLimitExceeded(final int listLimit) {
-    throw RangeError(
-      listLimit < 0
-          ? 'List parsing is disabled (listLimit < 0).'
-          : 'List limit exceeded. Only $listLimit '
-              'element${listLimit == 1 ? '' : 's'} allowed in a list.',
-    );
-  }
+  static Never throwListLimitExceeded(final int listLimit) => throw RangeError(
+        listLimit < 0
+            ? 'List parsing is disabled (listLimit < 0).'
+            : 'List limit exceeded. Only $listLimit '
+                'element${listLimit == 1 ? '' : 's'} allowed in a list.',
+      );
 
   static dynamic _enforceListLimit(
     final List<dynamic> result,

--- a/test/unit/decode_test.dart
+++ b/test/unit/decode_test.dart
@@ -602,6 +602,134 @@ void main() {
       );
     });
 
+    group('unbalanced bracket keys', () {
+      final cases = <(String, DecodeOptions, Map<String, dynamic>)>[
+        (
+          'a[bc=v',
+          const DecodeOptions(),
+          {
+            'a': {'[bc': 'v'}
+          }
+        ),
+        (
+          'a[=v',
+          const DecodeOptions(),
+          {
+            'a': {'[': 'v'}
+          }
+        ),
+        (
+          'a[b][c=v',
+          const DecodeOptions(),
+          {
+            'a': {
+              'b': {'[c': 'v'}
+            }
+          },
+        ),
+        (
+          'a[b]c[d=v',
+          const DecodeOptions(),
+          {
+            'a': {
+              'b': {'[d': 'v'}
+            }
+          },
+        ),
+        (
+          'filters[customtags:Env: Prod=v',
+          const DecodeOptions(),
+          {
+            'filters': {'[customtags:Env: Prod': 'v'}
+          },
+        ),
+        (
+          '][a=v',
+          const DecodeOptions(),
+          {
+            ']': {'[a': 'v'}
+          }
+        ),
+        (
+          'a][b=v',
+          const DecodeOptions(),
+          {
+            'a]': {'[b': 'v'}
+          }
+        ),
+        (
+          'a[b[c=v',
+          const DecodeOptions(),
+          {
+            'a': {'[b[c': 'v'}
+          }
+        ),
+        (
+          'a[b[c]=v',
+          const DecodeOptions(),
+          {
+            'a': {'[b[c]': 'v'}
+          }
+        ),
+        (
+          'a[b][c[d=v',
+          const DecodeOptions(),
+          {
+            'a': {
+              'b': {'[c[d': 'v'}
+            }
+          },
+        ),
+        ('[abc=v', const DecodeOptions(), {'[abc': 'v'}),
+        ('[[]b=v', const DecodeOptions(), {'[[]b': 'v'}),
+        (
+          'a[b]c[d]e[f=v',
+          const DecodeOptions(depth: 5),
+          {
+            'a': {
+              'b': {
+                'd': {'[f': 'v'}
+              }
+            }
+          },
+        ),
+        (
+          'a[b]c[d]e[f=v',
+          const DecodeOptions(depth: 1),
+          {
+            'a': {
+              'b': {'[d]e[f': 'v'}
+            }
+          },
+        ),
+        ('a[bc=v', const DecodeOptions(depth: 0), {'a[bc': 'v'}),
+        (
+          'a.b[c=v',
+          const DecodeOptions(allowDots: true),
+          {
+            'a': {
+              'b': {'[c': 'v'}
+            }
+          },
+        ),
+        ('a]b=v', const DecodeOptions(), {'a]b': 'v'}),
+        (
+          'a[b]extra=v',
+          const DecodeOptions(),
+          {
+            'a': {'b': 'v'}
+          },
+        ),
+      ];
+
+      for (final (input, options, expected) in cases) {
+        test('$input at depth ${options.depth}', () {
+          expect(() => QS.decode(input, options), returnsNormally);
+          expect(QS.decode(input, options), expected);
+        });
+      }
+    });
+
     test('parses a simple list', () {
       expect(
         QS.decode('a=b&a=c'),
@@ -2345,15 +2473,13 @@ void main() {
       );
     });
 
-    test('duplicate scalar overflow promotes to a map in strict mode', () {
+    test('duplicate scalar overflow throws in strict mode', () {
       expect(
-        QS.decode(
+        () => QS.decode(
           'a=1&a=2',
           const DecodeOptions(listLimit: 1, throwOnLimitExceeded: true),
         ),
-        equals({
-          'a': {'0': '1', '1': '2'}
-        }),
+        throwsRangeError,
       );
     });
 
@@ -2457,6 +2583,182 @@ void main() {
           const DecodeOptions(listLimit: 3, throwOnLimitExceeded: true),
         ),
         throwsA(isA<RangeError>()),
+      );
+    });
+  });
+
+  group('qs 6.15.3 list limit parity', () {
+    const strictOne = DecodeOptions(
+      listLimit: 1,
+      throwOnLimitExceeded: true,
+    );
+
+    test('throws when cumulative comma groups exceed listLimit', () {
+      expect(
+        () => QS.decode(
+          'a=1,2,3&a=4,5,6',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 5,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        throwsRangeError,
+      );
+      expect(
+        () => QS.decode(
+          'a=v,v,v,v,v&a=v,v,v,v,v&a=v,v,v,v,v',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 5,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        throwsRangeError,
+      );
+    });
+
+    test('throws when duplicate keys grow past the boundary', () {
+      expect(() => QS.decode('a=x&a=y', strictOne), throwsRangeError);
+      expect(() => QS.decode('a[]=x&a[]=y', strictOne), throwsRangeError);
+    });
+
+    test('throws when mixed notation grows past the boundary', () {
+      expect(() => QS.decode('a=x&a[0]=y', strictOne), throwsRangeError);
+      expect(() => QS.decode('a[0]=x&a=y', strictOne), throwsRangeError);
+      expect(() => QS.decode('a[0]=x&a[]=y', strictOne), throwsRangeError);
+    });
+
+    test('mixed notation becomes an overflow map in non-strict mode', () {
+      const options = DecodeOptions(listLimit: 1);
+      const expected = {
+        'a': {'0': 'x', '1': 'y'}
+      };
+
+      expect(QS.decode('a=x&a[0]=y', options), expected);
+      expect(QS.decode('a[0]=x&a=y', options), expected);
+      expect(QS.decode('a[0]=x&a[]=y', options), expected);
+      expect(Utils.isOverflow(QS.decode('a[0]=x&a=y', options)['a']), isTrue);
+    });
+
+    test('cumulative comma groups become an overflow map in non-strict mode',
+        () {
+      final result = QS.decode(
+        'a=1,2,3&a=4,5,6',
+        const DecodeOptions(comma: true, listLimit: 5),
+      );
+
+      expect(result, {
+        'a': {'0': '1', '1': '2', '2': '3', '3': '4', '4': '5', '5': '6'}
+      });
+      expect(Utils.isOverflow(result['a']), isTrue);
+    });
+
+    test('throws before decoding an oversized flat comma value', () {
+      int decodedValues = 0;
+      final options = DecodeOptions(
+        comma: true,
+        listLimit: 1,
+        throwOnLimitExceeded: true,
+        decoder: (
+          String? value, {
+          Encoding? charset,
+          DecodeKind? kind,
+        }) {
+          if (kind == DecodeKind.value) decodedValues++;
+          return Utils.decode(value, charset: charset);
+        },
+      );
+
+      expect(() => QS.decode('a=1,2', options), throwsRangeError);
+      expect(decodedValues, 0);
+    });
+
+    test('throws for oversized nested flat comma values', () {
+      expect(
+        () => QS.decode(
+          'a[b]=1,2,3,4,5,6',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 5,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        throwsRangeError,
+      );
+    });
+
+    test('keeps comma values at or below listLimit', () {
+      expect(
+        QS.decode(
+          'a=1,2,3&a=4',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 5,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        {
+          'a': ['1', '2', '3', '4']
+        },
+      );
+      expect(
+        QS.decode(
+          'a=1,2,3,4,5',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 5,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        {
+          'a': ['1', '2', '3', '4', '5']
+        },
+      );
+    });
+
+    test('counts bracketed comma groups as nested elements', () {
+      expect(
+        QS.decode(
+          'a[]=1,2,3&a[]=4,5,6',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 5,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        {
+          'a': [
+            ['1', '2', '3'],
+            ['4', '5', '6'],
+          ]
+        },
+      );
+      expect(
+        QS.decode(
+          'a[]=1,2,3,4,5,6',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 5,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        {
+          'a': [
+            ['1', '2', '3', '4', '5', '6']
+          ]
+        },
+      );
+      expect(
+        () => QS.decode(
+          'a[]=1,2,3',
+          const DecodeOptions(
+            comma: true,
+            listLimit: 0,
+            throwOnLimitExceeded: true,
+          ),
+        ),
+        throwsRangeError,
       );
     });
   });
@@ -2667,8 +2969,8 @@ void main() {
 
       final resultOne =
           QS.decode('a[]=b&a[0]=c', const DecodeOptions(listLimit: 1));
-      expect(resultOne['a'], ['b', 'c']);
-      expect(Utils.isOverflow(resultOne['a']), isFalse);
+      expect(resultOne['a'], {'0': 'b', '1': 'c'});
+      expect(Utils.isOverflow(resultOne['a']), isTrue);
     });
 
     test('mixed [0] and [] under tight listLimit', () {
@@ -2682,8 +2984,8 @@ void main() {
 
       final resultOne =
           QS.decode('a[0]=b&a[]=c', const DecodeOptions(listLimit: 1));
-      expect(resultOne['a'], ['b', 'c']);
-      expect(Utils.isOverflow(resultOne['a']), isFalse);
+      expect(resultOne['a'], {'0': 'b', '1': 'c'});
+      expect(Utils.isOverflow(resultOne['a']), isTrue);
     });
 
     test('mixed notation produces consistent overflow results', () {

--- a/test/unit/utils_test.dart
+++ b/test/unit/utils_test.dart
@@ -952,6 +952,61 @@ void main() {
         );
       });
 
+      group('with listLimit', () {
+        const strictOne = DecodeOptions(
+          listLimit: 1,
+          throwOnLimitExceeded: true,
+        );
+        const softOne = DecodeOptions(listLimit: 1);
+
+        test('converts primitive growth past the boundary to an overflow map',
+            () {
+          final merged = Utils.merge(['a'], 'b', softOne);
+
+          expect(merged, {'0': 'a', '1': 'b'});
+          expect(Utils.isOverflow(merged), isTrue);
+        });
+
+        test('converts scalar-list growth past the boundary to an overflow map',
+            () {
+          final merged = Utils.merge('a', ['b', 'c'], softOne);
+
+          expect(merged, {'0': 'a', '1': 'b', '2': 'c'});
+          expect(Utils.isOverflow(merged), isTrue);
+        });
+
+        test('converts list-list growth past the boundary to an overflow map',
+            () {
+          final merged = Utils.merge(['a'], ['b'], softOne);
+
+          expect(merged, {'0': 'a', '1': 'b'});
+          expect(Utils.isOverflow(merged), isTrue);
+        });
+
+        test('throws for every list growth path past the boundary', () {
+          expect(() => Utils.merge(['a'], 'b', strictOne), throwsRangeError);
+          expect(
+            () => Utils.merge('a', ['b', 'c'], strictOne),
+            throwsRangeError,
+          );
+          expect(
+            () => Utils.merge(['a'], ['b'], strictOne),
+            throwsRangeError,
+          );
+        });
+
+        test('keeps values at the boundary as a list', () {
+          expect(Utils.merge(<String>[], 'a', strictOne), ['a']);
+        });
+
+        test('preserves Set-specific behavior', () {
+          expect(
+            Utils.merge({'a'}, {'b'}, strictOne),
+            {'a', 'b'},
+          );
+        });
+      });
+
       group('with overflow objects (from listLimit)', () {
         test('merges primitive into overflow object at next index', () {
           final overflow =
@@ -1107,6 +1162,57 @@ void main() {
             {'0': 'a', '1': 'b'},
             'c'
           ]);
+        });
+
+        test('throws before mutating an existing overflow object', () {
+          final overflow =
+              Utils.combine(['a'], 'b', listLimit: 1) as Map<String, dynamic>;
+
+          expect(
+            () => Utils.combine(
+              overflow,
+              'c',
+              listLimit: 1,
+              throwOnLimitExceeded: true,
+            ),
+            throwsRangeError,
+          );
+          expect(overflow, {'0': 'a', '1': 'b'});
+        });
+      });
+
+      group('with throwOnLimitExceeded', () {
+        test('throws when concatenation exceeds the limit', () {
+          expect(
+            () => Utils.combine(
+              ['a', 'b', 'c'],
+              'd',
+              listLimit: 3,
+              throwOnLimitExceeded: true,
+            ),
+            throwsRangeError,
+          );
+          expect(
+            () => Utils.combine(
+              [],
+              'a',
+              listLimit: 0,
+              throwOnLimitExceeded: true,
+            ),
+            throwsRangeError,
+          );
+        });
+
+        test('returns a list while within the limit', () {
+          expect(
+            Utils.combine(
+              ['a'],
+              'b',
+              listLimit: 5,
+              throwOnLimitExceeded: true,
+            ),
+            ['a', 'b'],
+          );
         });
       });
     });
@@ -1265,6 +1371,21 @@ void main() {
         expect((out['parent'] as Map).containsKey('u'), isFalse);
       });
 
+      test('handles multi-step cycles without infinite loop', () {
+        final a = <String, dynamic>{};
+        final b = <String, dynamic>{};
+        final c = <String, dynamic>{};
+        a['b'] = b;
+        b['c'] = c;
+        c['d'] = a;
+        c['u'] = const Undefined();
+
+        final out = Utils.compact(a);
+
+        expect(((out['b'] as Map)['c'] as Map)['d'], same(out));
+        expect(((out['b'] as Map)['c'] as Map).containsKey('u'), isFalse);
+      });
+
       test('preserves order', () {
         final m = <String, dynamic>{
           'first': 1,
@@ -1293,6 +1414,44 @@ void main() {
     });
 
     group('utils surrogate and charset edge cases (coverage)', () {
+      test('encodes a surrogate pair split across the first chunk boundary',
+          () {
+        final input = '${'a' * 1023}😀';
+
+        expect(Utils.encode(input), '${'a' * 1023}%F0%9F%98%80');
+      });
+
+      test('encodes a surrogate pair split across a later chunk boundary', () {
+        final input = '${'a' * 2047}😀';
+
+        expect(Utils.encode(input), '${'a' * 2047}%F0%9F%98%80');
+      });
+
+      test('encodes multiple boundary-split surrogate pairs', () {
+        final input = '${'a' * 1023}😀${'b' * 1022}😀';
+
+        expect(
+          RegExp('%F0%9F%98%80').allMatches(Utils.encode(input)).length,
+          2,
+        );
+      });
+
+      test('round-trips a boundary-split surrogate pair', () {
+        final input = '${'a' * 1023}😀';
+
+        expect(Uri.decodeComponent(Utils.encode(input)), input);
+      });
+
+      test('keeps lone high-surrogate behavior stable at a chunk boundary', () {
+        final input = '${'a' * 1023}\uD83DX';
+
+        expect(
+          Utils.encode(input).substring(1023),
+          Utils.encode('\uD83DX'),
+        );
+        expect(Utils.encode(input), endsWith('%ED%A0%BDX'));
+      });
+
       test('lone high surrogate encoded as three UTF-8 bytes', () {
         const loneHigh = '\uD800';
         final encoded = QS.encode({'s': loneHigh});


### PR DESCRIPTION
This pull request focuses on improving how list limits and error handling are enforced during query string (`qs`) decoding, ensuring stricter compliance with Node `qs` 6.15.3 behavior. It also adds regression test coverage for edge cases and unbalanced bracket keys. The main changes include stricter enforcement of list limits (with exceptions thrown when exceeded in strict mode), unification of error handling logic, and expanded test cases to match Node `qs` behavior.

**List limit enforcement and error handling:**

* Introduced `Utils.throwListLimitExceeded()` to standardize throwing a `RangeError` when the list limit is exceeded, and replaced all previous ad hoc error messages and throws with this utility. [[1]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dR68-R90) [[2]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fR49-L69) [[3]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL80-R94) [[4]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL468-R488)
* Updated `Utils.combine()` and all internal merging logic to throw immediately (when `throwOnLimitExceeded` is enabled) instead of returning an overflow map, for both flat comma lists and incremental list growth. [[1]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL871-R905) [[2]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dR916-R921) [[3]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dR942-R944) [[4]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL331-R351) [[5]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL431-R451)
* Added pre-allocation checks for flat comma-separated values to reject oversized values before splitting and allocating memory, matching Node `qs` cumulative enforcement. [[1]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fR49-L69) [[2]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fR310)

**Behavioral and compatibility improvements:**

* Ensured that duplicate key combinations and mixed list merges enforce the cumulative list limit across all code paths, matching Node `qs` 6.15.3. [[1]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fL331-R351) [[2]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fR310) [[3]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL185-R213) [[4]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL206-R245) [[5]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dR297-R302) [[6]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL319-R346) [[7]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL329-R356) [[8]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL416-R445)
* Updated error handling in tests to expect exceptions (not overflow maps) when strict list limits are exceeded.

**Regression test coverage:**

* Added comprehensive tests for unbalanced bracket keys, chunk-boundary surrogate pairs, and cyclic compaction to match Node `qs` 6.15.3 regression coverage.

**Documentation and housekeeping:**

* Updated documentation and comments to clarify the semantics of flat vs. nested list values, and documented new error handling logic. [[1]](diffhunk://#diff-940ba04eaf5622e85c6ff07a147048e5dac3f994c630da9b3b6a32bd29eaff8fR37-R38) [[2]](diffhunk://#diff-17db63ed2e34bd40b2bf89c04f997ba760e4fd75b04e6cf03f58349bd458477dL871-R905)
* Updated `CHANGELOG.md` to reflect the bug fixes, new strict error handling, and new regression test coverage.